### PR TITLE
Add cocal to main of the development fork for auto_selfcal

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -732,13 +732,14 @@ for band in bands:
 
     # Update the relevant lists if we are going to do a fallback mode.
     if len(fallback_fields[band]) > 0:
-        solints[band] += ["inf_EB_fb","inf_fb"]
-        solmode[band] += ["p","p"]
-        gaincal_combine[band] += gaincal_combine[band][0:2]
-        applycal_mode[band] += applycal_mode[band][0:2]
-        calibrators[band] = [inf_EB_fields[band], inf_fields[band]]
+        solints[band] += ["inf_EB_fb","inf_fb1","inf_fb2","inf_fb3"]
+        solmode[band] += ["p","p","p","p"]
+        gaincal_combine[band] += [gaincal_combine[band][0], gaincal_combine[band][1], gaincal_combine[band][1], gaincal_combine[band][1]]
+        applycal_mode[band] += [applycal_mode[band][0], applycal_mode[band][1], applycal_mode[band][1], applycal_mode[band][1]]
+        calibrators[band] = [inf_EB_fields[band], inf_fields[band], inf_fields[band], inf_fields[band]]
         for target in all_targets:
-            selfcal_library[target][band]["nsigma"] = np.concatenate((selfcal_library[target][band]["nsigma"],selfcal_library[target][band]["nsigma"][0:2]))
+            selfcal_library[target][band]["nsigma"] = np.concatenate((selfcal_library[target][band]["nsigma"],[selfcal_library[target][band]["nsigma"][0], \
+                    selfcal_library[target][band]["nsigma"][1], selfcal_library[target][band]["nsigma"][1], selfcal_library[target][band]["nsigma"][1]]))
 
 print(inf_EB_fields)
 print(inf_fields)
@@ -762,7 +763,7 @@ for target in all_targets:
     inf_EB_fallback_mode_dict[target][band][vis]='' #'scan'
 
 
-calculate_inf_EB_fb_anyways = False
+calculate_inf_EB_fb_anyways = True
 preapply_targets_own_inf_EB = False
 
 ## The below sets the calibrations back to what they were prior to starting the fallback mode. It should not be needed

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -806,8 +806,8 @@ for target in all_targets:
    if target not in fallback_fields[band]:
        continue
 
-   run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_per_field, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize, imsize, \
-           inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp, integration_time, \
+   run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_per_field, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize[target], imsize[target], \
+           inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp[target], integration_time, \
            gaincal_minsnr=gaincal_minsnr, gaincal_unflag_minsnr=gaincal_unflag_minsnr, minsnr_to_proceed=minsnr_to_proceed, delta_beam_thresh=delta_beam_thresh, do_amp_selfcal=do_amp_selfcal, \
            inf_EB_gaincal_combine=inf_EB_gaincal_combine, inf_EB_gaintype=inf_EB_gaintype, unflag_only_lbants=unflag_only_lbants, \
            unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, \

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -859,13 +859,13 @@ for target in all_targets:
        continue
 
    run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_per_field, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize[target], imsize[target], \
-           inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp[target], integration_time, \
+           inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp[target], integration_time, spectral_scan, spws_set,\
            gaincal_minsnr=gaincal_minsnr, gaincal_unflag_minsnr=gaincal_unflag_minsnr, minsnr_to_proceed=minsnr_to_proceed, delta_beam_thresh=delta_beam_thresh, do_amp_selfcal=do_amp_selfcal, \
            inf_EB_gaincal_combine=inf_EB_gaincal_combine, inf_EB_gaintype=inf_EB_gaintype, unflag_only_lbants=unflag_only_lbants, \
            unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, \
            second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, rerank_refants=rerank_refants, \
            mode="cocal", calibrators=calibrators, calculate_inf_EB_fb_anyways=calculate_inf_EB_fb_anyways, \
-           preapply_targets_own_inf_EB=preapply_targets_own_inf_EB, gaincalibrator_dict=gaincalibrator_dict)
+           preapply_targets_own_inf_EB=preapply_targets_own_inf_EB, gaincalibrator_dict=gaincalibrator_dict, allow_gain_interpolation=True)
 
 print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -705,8 +705,9 @@ for vis in vislist:
 ## For sources that self-calibration failed, try to use the inf_EB and the inf solutions from the sources that
 ## were successful.
 
-for source in selfcal_library.keys():
-    print(source, selfcal_library[source][band]["final_solint"])
+for target in selfcal_library.keys():
+    for band in selfcal_library[target].keys()
+        print(target, selfcal_library[target][band]["final_solint"])
 
 inf_EB_fields = {}
 inf_fields = {}

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -643,14 +643,12 @@ print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 ##
 ## Save the flags following the main iteration of self-calibration since we will need to revert to the beginning for the fallback mode.
 ##
-"""
 # PS: I don't need this anymore?
 for vis in vislist:
    if not os.path.exists(vis+'.flagversions/flags.fb_selfcal_starting_flags'):
       flagmanager(vis=vis,mode='save',versionname='fb_selfcal_starting_flags')
    else:
       flagmanager(vis=vis,mode='restore',versionname='fb_selfcal_starting_flags')
-"""
 
 ##
 ## For sources that self-calibration failed, try to use the inf_EB and the inf solutions from the sources that
@@ -662,6 +660,7 @@ for source in selfcal_library.keys():
 inf_EB_fields = {}
 inf_fields = {}
 fallback_fields = {}
+calibrators = {}
 for band in bands:
     # Initialize the lists for this band.
     inf_EB_fields[band] = []
@@ -757,7 +756,8 @@ for target in all_targets:
            inf_EB_gaincal_combine=inf_EB_gaincal_combine, inf_EB_gaintype=inf_EB_gaintype, unflag_only_lbants=unflag_only_lbants, \
            unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, \
            second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, rerank_refants=rerank_refants, \
-           mode="cocal", calibrators=calibrators)
+           mode="cocal", calibrators=calibrators, calculate_inf_EB_fb_anyways=calculate_inf_EB_fb_anyways, \
+           preapply_targets_own_inf_EB=preapply_targets_own_inf_EB)
 
 print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -706,7 +706,7 @@ for vis in vislist:
 ## were successful.
 
 for target in selfcal_library.keys():
-    for band in selfcal_library[target].keys()
+    for band in selfcal_library[target].keys():
         print(target, selfcal_library[target][band]["final_solint"])
 
 inf_EB_fields = {}

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -706,7 +706,7 @@ for vis in vislist:
 ## were successful.
 
 for source in selfcal_library.keys():
-    print(source, selfcal_library[source]["Band_7"]["final_solint"])
+    print(source, selfcal_library[source][band]["final_solint"])
 
 inf_EB_fields = {}
 inf_fields = {}
@@ -720,9 +720,9 @@ for band in bands:
 
     # Loop through and identify which sources belong where.
     for target in selfcal_library.keys():
-        if selfcal_library[target]['Band_7']['SC_success'] and 'fb' not in selfcal_library[target]['Band_7']['final_solint']:
+        if selfcal_library[target][band]['SC_success'] and 'fb' not in selfcal_library[target][band]['final_solint']:
             inf_EB_fields[band].append(target)
-            if selfcal_library[target]['Band_7']['final_solint'] != 'inf_EB':
+            if selfcal_library[target][band]['final_solint'] != 'inf_EB':
                 inf_fields[band].append(target)
             elif 'inf' in solints[band]:
                 fallback_fields[band].append(target)
@@ -767,12 +767,12 @@ preapply_targets_own_inf_EB = False
 ## The below sets the calibrations back to what they were prior to starting the fallback mode. It should not be needed
 ## for the final version of the codue, but is used for testing.
 
-fb_list = fallback_fields["Band_7"]
 
-
-for target in fb_list:
+for target in all_targets:
  sani_target=sanitize_string(target)
  for band in selfcal_library[target].keys():
+   if target not in fallback_fields[band]:
+       continue
    if 'gaintable_final' in selfcal_library[target][band][vislist[0]]:
       print('****************Reapplying previous solint solutions*************')
       for vis in vislist:

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -71,6 +71,7 @@ rerank_refants=False
 allow_gain_interpolation=False
 guess_scan_combine=False
 aca_use_nfmask=False
+allow_cocal=False
 scale_fov=1.0   # option to make field of view larger than the default
 rel_thresh_scaling='log10'  #can set to linear, log10, or loge (natural log)
 dividing_factor=-99.0  # number that the peak SNR is divided by to determine first clean threshold -99.0 uses default
@@ -758,127 +759,128 @@ for target in all_targets:
 print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 
 
-##
-## Save the flags following the main iteration of self-calibration since we will need to revert to the beginning for the fallback mode.
-##
-# PS: I don't need this anymore?
-for vis in vislist:
-   if not os.path.exists(vis+'.flagversions/flags.fb_selfcal_starting_flags'):
-      flagmanager(vis=vis,mode='save',versionname='fb_selfcal_starting_flags')
-   else:
-      flagmanager(vis=vis,mode='restore',versionname='fb_selfcal_starting_flags')
-
-##
-## For sources that self-calibration failed, try to use the inf_EB and the inf solutions from the sources that
-## were successful.
-
-for target in selfcal_library.keys():
-    for band in selfcal_library[target].keys():
-        print(target, selfcal_library[target][band]["final_solint"])
-
-inf_EB_fields = {}
-inf_fields = {}
-fallback_fields = {}
-calibrators = {}
-for band in bands:
-    # Initialize the lists for this band.
-    inf_EB_fields[band] = []
-    inf_fields[band] = []
-    fallback_fields[band] = []
-
-    # Loop through and identify which sources belong where.
+if allow_cocal:
+    ##
+    ## Save the flags following the main iteration of self-calibration since we will need to revert to the beginning for the fallback mode.
+    ##
+    # PS: I don't need this anymore?
+    for vis in vislist:
+       if not os.path.exists(vis+'.flagversions/flags.fb_selfcal_starting_flags'):
+          flagmanager(vis=vis,mode='save',versionname='fb_selfcal_starting_flags')
+       else:
+          flagmanager(vis=vis,mode='restore',versionname='fb_selfcal_starting_flags')
+    
+    ##
+    ## For sources that self-calibration failed, try to use the inf_EB and the inf solutions from the sources that
+    ## were successful.
+    
     for target in selfcal_library.keys():
-        if selfcal_library[target][band]['SC_success'] and 'fb' not in selfcal_library[target][band]['final_solint']:
-            inf_EB_fields[band].append(target)
-            if selfcal_library[target][band]['final_solint'] != 'inf_EB':
-                inf_fields[band].append(target)
-            elif 'inf' in solints[band][target]:
+        for band in selfcal_library[target].keys():
+            print(target, selfcal_library[target][band]["final_solint"])
+    
+    inf_EB_fields = {}
+    inf_fields = {}
+    fallback_fields = {}
+    calibrators = {}
+    for band in bands:
+        # Initialize the lists for this band.
+        inf_EB_fields[band] = []
+        inf_fields[band] = []
+        fallback_fields[band] = []
+    
+        # Loop through and identify which sources belong where.
+        for target in selfcal_library.keys():
+            if selfcal_library[target][band]['SC_success'] and 'fb' not in selfcal_library[target][band]['final_solint']:
+                inf_EB_fields[band].append(target)
+                if selfcal_library[target][band]['final_solint'] != 'inf_EB':
+                    inf_fields[band].append(target)
+                elif 'inf' in solints[band][target]:
+                    fallback_fields[band].append(target)
+            else:
                 fallback_fields[band].append(target)
-        else:
-            fallback_fields[band].append(target)
-
-        # Update the relevant lists if we are going to do a fallback mode.
-        if len(fallback_fields[band]) > 0:
-            solints[band][target] += ["inf_EB_fb","inf_fb1","inf_fb2","inf_fb3"]
-            solmode[band][target] += ["p","p","p","p"]
-            gaincal_combine[band][target] += [gaincal_combine[band][target][0], gaincal_combine[band][target][1], gaincal_combine[band][target][1], gaincal_combine[band][target][1]]
-            applycal_mode[band][target] += [applycal_mode[band][target][0], applycal_mode[band][target][1], applycal_mode[band][target][1], applycal_mode[band][target][1]]
-            calibrators[band] = [inf_EB_fields[band], inf_fields[band], inf_fields[band], inf_fields[band]]
-            selfcal_library[target][band]["nsigma"] = np.concatenate((selfcal_library[target][band]["nsigma"],[selfcal_library[target][band]["nsigma"][0], \
-                    selfcal_library[target][band]["nsigma"][1], selfcal_library[target][band]["nsigma"][1], selfcal_library[target][band]["nsigma"][1]]))
-
-print(inf_EB_fields)
-print(inf_fields)
-print(fallback_fields)
-
-##
-## Reset the inf_EB informational dictionaries.
-##
-
-for target in all_targets:
- for band in solint_snr[target].keys():
-   # If the target had a successful inf_EB solution, no need to reset.
-   if target in inf_EB_fields[band]:
-       continue
-
-   for vis in vislist:
-    inf_EB_gaincal_combine_dict[target][band][vis]=inf_EB_gaincal_combine #'scan'
-    if selfcal_library[target][band]['obstype']=='mosaic':
-       inf_EB_gaincal_combine_dict[target][band][vis]+=',field'   
-    inf_EB_gaintype_dict[target][band][vis]=inf_EB_gaintype #G
-    inf_EB_fallback_mode_dict[target][band][vis]='' #'scan'
-
-
-calculate_inf_EB_fb_anyways = True
-preapply_targets_own_inf_EB = False
-
-## The below sets the calibrations back to what they were prior to starting the fallback mode. It should not be needed
-## for the final version of the codue, but is used for testing.
-
-
-for target in all_targets:
- sani_target=sanitize_string(target)
- for band in selfcal_library[target].keys():
-   if target not in fallback_fields[band]:
-       continue
-   if 'gaintable_final' in selfcal_library[target][band][vislist[0]]:
-      print('****************Reapplying previous solint solutions*************')
-      for vis in vislist:
-         print('****************Applying '+str(selfcal_library[target][band][vis]['gaintable_final'])+' to '+target+' '+band+'*************')
-         ## NOTE: should this be selfcal_starting_flags instead of fb_selfcal_starting_flags ???
-         flagmanager(vis=vis,mode='delete',versionname='fb_selfcal_starting_flags_'+sani_target)
-         applycal(vis=vis,\
-                 gaintable=selfcal_library[target][band][vis]['gaintable_final'],\
-                 interp=selfcal_library[target][band][vis]['applycal_interpolate_final'],\
-                 calwt=True,spwmap=selfcal_library[target][band][vis]['spwmap_final'],\
-                 applymode=selfcal_library[target][band][vis]['applycal_mode_final'],\
-                 field=target,spw=selfcal_library[target][band][vis]['spws'])    
-   else:            
-      print('****************Removing all calibrations for '+target+' '+band+'**************')
-      for vis in vislist:
-         flagmanager(vis=vis,mode='delete',versionname='fb_selfcal_starting_flags_'+sani_target)
-         clearcal(vis=vis,field=target,spw=selfcal_library[target][band][vis]['spws'])
-## END
-            
-
-##
-## Begin fallback self-cal loops
-##
-for target in all_targets:
- for band in selfcal_library[target].keys():
-   if target not in fallback_fields[band]:
-       continue
-
-   run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_per_field, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize[target], imsize[target], \
-           inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp[target], integration_time, spectral_scan, spws_set,\
-           gaincal_minsnr=gaincal_minsnr, gaincal_unflag_minsnr=gaincal_unflag_minsnr, minsnr_to_proceed=minsnr_to_proceed, delta_beam_thresh=delta_beam_thresh, do_amp_selfcal=do_amp_selfcal, \
-           inf_EB_gaincal_combine=inf_EB_gaincal_combine, inf_EB_gaintype=inf_EB_gaintype, unflag_only_lbants=unflag_only_lbants, \
-           unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, \
-           second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, rerank_refants=rerank_refants, \
-           mode="cocal", calibrators=calibrators, calculate_inf_EB_fb_anyways=calculate_inf_EB_fb_anyways, \
-           preapply_targets_own_inf_EB=preapply_targets_own_inf_EB, gaincalibrator_dict=gaincalibrator_dict, allow_gain_interpolation=True)
-
-print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
+    
+            # Update the relevant lists if we are going to do a fallback mode.
+            if len(fallback_fields[band]) > 0:
+                solints[band][target] += ["inf_EB_fb","inf_fb1","inf_fb2","inf_fb3"]
+                solmode[band][target] += ["p","p","p","p"]
+                gaincal_combine[band][target] += [gaincal_combine[band][target][0], gaincal_combine[band][target][1], gaincal_combine[band][target][1], gaincal_combine[band][target][1]]
+                applycal_mode[band][target] += [applycal_mode[band][target][0], applycal_mode[band][target][1], applycal_mode[band][target][1], applycal_mode[band][target][1]]
+                calibrators[band] = [inf_EB_fields[band], inf_fields[band], inf_fields[band], inf_fields[band]]
+                selfcal_library[target][band]["nsigma"] = np.concatenate((selfcal_library[target][band]["nsigma"],[selfcal_library[target][band]["nsigma"][0], \
+                        selfcal_library[target][band]["nsigma"][1], selfcal_library[target][band]["nsigma"][1], selfcal_library[target][band]["nsigma"][1]]))
+    
+    print(inf_EB_fields)
+    print(inf_fields)
+    print(fallback_fields)
+    
+    ##
+    ## Reset the inf_EB informational dictionaries.
+    ##
+    
+    for target in all_targets:
+     for band in solint_snr[target].keys():
+       # If the target had a successful inf_EB solution, no need to reset.
+       if target in inf_EB_fields[band]:
+           continue
+    
+       for vis in vislist:
+        inf_EB_gaincal_combine_dict[target][band][vis]=inf_EB_gaincal_combine #'scan'
+        if selfcal_library[target][band]['obstype']=='mosaic':
+           inf_EB_gaincal_combine_dict[target][band][vis]+=',field'   
+        inf_EB_gaintype_dict[target][band][vis]=inf_EB_gaintype #G
+        inf_EB_fallback_mode_dict[target][band][vis]='' #'scan'
+    
+    
+    calculate_inf_EB_fb_anyways = True
+    preapply_targets_own_inf_EB = False
+    
+    ## The below sets the calibrations back to what they were prior to starting the fallback mode. It should not be needed
+    ## for the final version of the codue, but is used for testing.
+    
+    
+    for target in all_targets:
+     sani_target=sanitize_string(target)
+     for band in selfcal_library[target].keys():
+       if target not in fallback_fields[band]:
+           continue
+       if 'gaintable_final' in selfcal_library[target][band][vislist[0]]:
+          print('****************Reapplying previous solint solutions*************')
+          for vis in vislist:
+             print('****************Applying '+str(selfcal_library[target][band][vis]['gaintable_final'])+' to '+target+' '+band+'*************')
+             ## NOTE: should this be selfcal_starting_flags instead of fb_selfcal_starting_flags ???
+             flagmanager(vis=vis,mode='delete',versionname='fb_selfcal_starting_flags_'+sani_target)
+             applycal(vis=vis,\
+                     gaintable=selfcal_library[target][band][vis]['gaintable_final'],\
+                     interp=selfcal_library[target][band][vis]['applycal_interpolate_final'],\
+                     calwt=True,spwmap=selfcal_library[target][band][vis]['spwmap_final'],\
+                     applymode=selfcal_library[target][band][vis]['applycal_mode_final'],\
+                     field=target,spw=selfcal_library[target][band][vis]['spws'])    
+       else:            
+          print('****************Removing all calibrations for '+target+' '+band+'**************')
+          for vis in vislist:
+             flagmanager(vis=vis,mode='delete',versionname='fb_selfcal_starting_flags_'+sani_target)
+             clearcal(vis=vis,field=target,spw=selfcal_library[target][band][vis]['spws'])
+    ## END
+                
+    
+    ##
+    ## Begin fallback self-cal loops
+    ##
+    for target in all_targets:
+     for band in selfcal_library[target].keys():
+       if target not in fallback_fields[band]:
+           continue
+    
+       run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_per_field, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize[target], imsize[target], \
+               inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp[target], integration_time, spectral_scan, spws_set,\
+               gaincal_minsnr=gaincal_minsnr, gaincal_unflag_minsnr=gaincal_unflag_minsnr, minsnr_to_proceed=minsnr_to_proceed, delta_beam_thresh=delta_beam_thresh, do_amp_selfcal=do_amp_selfcal, \
+               inf_EB_gaincal_combine=inf_EB_gaincal_combine, inf_EB_gaintype=inf_EB_gaintype, unflag_only_lbants=unflag_only_lbants, \
+               unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, \
+               second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, rerank_refants=rerank_refants, \
+               mode="cocal", calibrators=calibrators, calculate_inf_EB_fb_anyways=calculate_inf_EB_fb_anyways, \
+               preapply_targets_own_inf_EB=preapply_targets_own_inf_EB, gaincalibrator_dict=gaincalibrator_dict, allow_gain_interpolation=True)
+    
+    print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 
 ##
 ## If we want to try amplitude selfcal, should we do it as a function out of the main loop or a separate loop?

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -799,14 +799,14 @@ for target in all_targets:
    if target not in fallback_fields[band]:
        continue
 
-   run_selfcal(selfcal_library, target, band, solints, solint_snr, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize, imsize, \
+   run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_per_field, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize, imsize, \
            inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp, integration_time, \
-           gaincal_minsnr=gaincal_minsnr, minsnr_to_proceed=minsnr_to_proceed, delta_beam_thresh=delta_beam_thresh, do_amp_selfcal=do_amp_selfcal, \
+           gaincal_minsnr=gaincal_minsnr, gaincal_unflag_minsnr=gaincal_unflag_minsnr, minsnr_to_proceed=minsnr_to_proceed, delta_beam_thresh=delta_beam_thresh, do_amp_selfcal=do_amp_selfcal, \
            inf_EB_gaincal_combine=inf_EB_gaincal_combine, inf_EB_gaintype=inf_EB_gaintype, unflag_only_lbants=unflag_only_lbants, \
            unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, \
            second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, rerank_refants=rerank_refants, \
            mode="cocal", calibrators=calibrators, calculate_inf_EB_fb_anyways=calculate_inf_EB_fb_anyways, \
-           preapply_targets_own_inf_EB=preapply_targets_own_inf_EB)
+           preapply_targets_own_inf_EB=preapply_targets_own_inf_EB, gaincalibrator_dict=gaincalibrator_dict)
 
 print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -475,7 +475,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                         selfcal_library[target][band][vis][solint]["include_targets"] = include_targets
 
                         for incl_scans, incl_targets in zip(include_scans, include_targets):
-                            if solint == 'inf_EB':
+                            if 'inf_EB' in solint:
                                if spws_set[band][vis].ndim == 1:
                                   nspw_sets=1
                                else:
@@ -483,7 +483,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                             else: #only necessary to loop over gain cal when in inf_EB to avoid inf_EB solving for all spws
                                nspw_sets=1
                             for i in range(nspw_sets):  # run gaincal on each spw set to handle spectral scans
-                               if solint == 'inf_EB':
+                               if 'inf_EB' in solint:
                                   if nspw_sets == 1 and spws_set[band][vis].ndim == 1:
                                      spwselect=','.join(str(spw) for spw in spws_set[band][vis].tolist())
                                   else:
@@ -498,7 +498,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                                  field=incl_targets,scan=incl_scans,gaintable=gaincal_preapply_gaintable[vis],spwmap=gaincal_spwmap[vis],uvrange=selfcal_library[target][band]['uvrange'],
                                  interp=gaincal_interpolate[vis], solmode=gaincal_solmode, refantmode='flex', append=os.path.exists(sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g'))
                                #
-                               if solint != 'inf_EB':
+                               if 'inf_EB' not in solint:
                                   break
                 else:
                     for fid in np.intersect1d(selfcal_library[target][band]['sub-fields-to-selfcal'],list(selfcal_library[target][band]['sub-fields-fid_map'][vis].keys())):

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -926,10 +926,10 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                 selfcal_library[target][band][vis][solint]['SNR_NF_post']=post_SNR_NF.copy()
                 selfcal_library[target][band][vis][solint]['RMS_NF_post']=post_RMS_NF.copy()
                 ## Update RMS value if necessary
-                if selfcal_library[target][band][vis][solint]['RMS_post'] < selfcal_library[target][band]['RMS_curr'] and "inf_EB_fb" not in solint 
-                        and vis == vislist[-1]:
+                if selfcal_library[target][band][vis][solint]['RMS_post'] < selfcal_library[target][band]['RMS_curr'] and \
+                        "inf_EB_fb" not in solint and vis == vislist[-1]:
                    selfcal_library[target][band]['RMS_curr']=selfcal_library[target][band][vis][solint]['RMS_post'].copy()
-                if selfcal_library[target][band][vis][solint]['RMS_NF_post'] < selfcal_library[target][band]['RMS_NF_curr'] and 
+                if selfcal_library[target][band][vis][solint]['RMS_NF_post'] < selfcal_library[target][band]['RMS_NF_curr'] and \
                         "inf_EB_fb" not in solint and selfcal_library[target][band][vis][solint]['RMS_NF_post'] > 0 and vis == vislist[-1]:
                    selfcal_library[target][band]['RMS_NF_curr']=selfcal_library[target][band][vis][solint]['RMS_NF_post'].copy()
                 header=imhead(imagename=sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.image.tt0')

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -502,7 +502,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                      gaintype=gaincal_gaintype, spw=selfcal_library[target][band][vis]['spws'],
                      refant=selfcal_library[target][band][vis]['refant'], calmode='p', 
                      solint=solint.replace('_EB','').replace('_ap','').replace('_fb',''),minsnr=gaincal_minsnr if applymode == "calflag" else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=test_gaincal_combine,
-                     field=include_targets,scan=include_scans[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode='flex') 
+                     field=include_targets[0],scan=include_scans[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode='flex') 
                    spwlist=selfcal_library[target][band][vis]['spws'].split(',')
                    fallback[vis],map_index,spwmap,applycal_spwmap_inf_EB=analyze_inf_EB_flagging(selfcal_library,band,spwlist,sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][iteration]+'.g',vis,target,'test_inf_EB.g')
 

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -479,7 +479,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                      gaintype=gaincal_gaintype, spw=selfcal_library[target][band][vis]['spws'],
                      refant=selfcal_library[target][band][vis]['refant'], calmode='p', 
                      solint=solint.replace('_EB','').replace('_ap','').replace('_fb',''),minsnr=gaincal_minsnr if applymode == "calflag" else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=test_gaincal_combine,
-                     field=include_targets,scan=include_scans,gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode=refantmode) 
+                     field=include_targets,scan=include_scans[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode=refantmode) 
                    spwlist=selfcal_library[target][band][vis]['spws'].split(',')
                    fallback[vis],map_index,spwmap,applycal_spwmap_inf_EB=analyze_inf_EB_flagging(selfcal_library,band,spwlist,sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][iteration]+'.g',vis,target,'test_inf_EB.g')
 

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -808,7 +808,8 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                  if iteration > 0: # reapply only the previous gain tables, to get rid of solutions from this selfcal round
                     print('****************Reapplying previous solint solutions*************')
                     for vis in vislist:
-                       flagmanager(vis=vis,mode='restore',versionname='selfcal_starting_flags_'+sani_target)
+                       versionname = ("fb_" if mode == "cocal" else "")+'selfcal_starting_flags_'+sani_target
+                       flagmanager(vis=vis,mode='restore',versionname=versionname)
                        for fid in selfcal_library[target][band]['sub-fields']:
                            if selfcal_library[target][band][fid]['SC_success']:
                                print('****************Applying '+str(selfcal_library[target][band][vis]['gaintable_final'])+' to '+target+\

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -44,6 +44,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
        include_targets, include_scans = triage_calibrators(vislist[0], target, calibrators[band][0])
        if include_targets == "":
            print("No suitable calibrators found, skipping "+target)
+           selfcal_library[target][band]['Stop_Reason'] += '; No suitable co-calibrators'
            return
 
    print('Starting selfcal procedure on: '+target+' '+band)

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -301,7 +301,12 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                         ##
                         destination_table = sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][iteration]+'.g'
                         for t in include_targets.split(","):
-                            table_name = sanitize_string(t)+'_'+vis+'_'+band+'_'+solint.replace('_fb','')+'_'+str(1)+'_'+solmode[band][iteration]+'.g'
+                            if os.path.exists(sanitize_string(t)+'_'+vis+'_'+band+'_'+solint.replace('_fb','')+'_'+str(1)+'_'+solmode[band][iteration]+\
+                                    '.pre-pass.g'):
+                                table_name = sanitize_string(t)+'_'+vis+'_'+band+'_'+solint.replace('_fb','')+'_'+str(1)+'_'+solmode[band][iteration]+\
+                                        '.pre-pass.g'
+                            else:
+                                table_name = sanitize_string(t)+'_'+vis+'_'+band+'_'+solint.replace('_fb','')+'_'+str(1)+'_'+solmode[band][iteration]+'.g'
                             #t_final_solint = selfcal_library[t][band]["final_phase_solint"]
                             #t_iteration = selfcal_library[t][band][vislist[0]][t_final_solint]["iteration"]
                             #table_name = sanitize_string(t)+'_'+vis+'_'+band+'_'+t_final_solint+'_'+str(t_iteration)+'_'+solmode[band][iteration]+'.g'

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1056,6 +1056,11 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                 print('****************Selfcal passed, shortening solint*************')
              else:
                 print('****************Selfcal passed for Minimum solint*************')
+         elif mode == "cocal" and solint == "inf_EB_fb" and (selfcal_library[target][band][vislist[0]]["inf_EB"]['Pass'] if "inf_EB" in \
+                 selfcal_library[target][band][vislist[0]] else False):
+            print('****************Selfcal failed for inf_EB_fb, skipping inf_fb1*****************')
+            iterjump = solints[band].index('inf_fb2')
+            continue
          else:   
             print('****************Selfcal failed*************')
             print('REASON: '+reason)

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -344,7 +344,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                         # Flag all of the scans that failed the triage above.
                         if preapply_targets_own_inf_EB and solint == "inf_fb":
                             good_scans = np.repeat(False, antennas.size)
-                            for scan in include_scans.split(","):
+                            for scan in include_scans[0].split(","):
                                 good_scans[scans == int(scan)] = True
                             print("# of good scans data:", good_scans.sum())
                             print("# of scans data:", good_scans.size)

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -68,6 +68,9 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
       elif solints[band][iteration] == "inf_fb3":
           calculate_inf_EB_fb_anyways = False
           preapply_targets_own_inf_EB = True
+          # If there was no inf solint (e.g. because each source was observed only a single time, skip this as there are no gain tables to stick together.
+          if "inf" not in solints[band]:
+              continue
 
       if mode == "selfcal" and solint_snr[target][band][solints[band][iteration]] < minsnr_to_proceed and np.all([solint_snr_per_field[target][band][fid][solints[band][iteration]] < minsnr_to_proceed for fid in selfcal_library[target][band]['sub-fields']]):
          print('*********** estimated SNR for solint='+solints[band][iteration]+' too low, measured: '+str(solint_snr[target][band][solints[band][iteration]])+', Min SNR Required: '+str(minsnr_to_proceed)+' **************')

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -266,7 +266,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                           applycal_spwmap[vis]=[selfcal_library[target][band][vis]['spwmap']]
                           gaincal_spwmap[vis]=[selfcal_library[target][band][vis]['spwmap']]
                        else:
-                          applycal_spwmap[vis]=[]
+                          applycal_spwmap[vis]=[[]]
                        applycal_interpolate[vis]=[applycal_interp[band]]
                        applycal_gaintable[vis]=[sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g']
                     #elif solmode[band][target][iteration]=='p':
@@ -310,7 +310,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                            if selfcal_library[target][band]['final_solint'] == 'inf_EB' and calculate_inf_EB_fb_anyways:
                                previous_solint = "inf_EB"
 
-                       applycal_spwmap[vis] = [selfcal_library[target][band][vis][previous_solint]['spwmap']] + [selfcal_library[target][band][vis]['spwmap']]
+                       applycal_spwmap[vis] = selfcal_library[target][band][vis][previous_solint]['spwmap'] + [selfcal_library[target][band][vis]['spwmap']]
                        applycal_interpolate[vis]=[applycal_interp[band],applycal_interp[band]]
                        applycal_gaintable[vis] = selfcal_library[target][band][vis][previous_solint]['gaintable'] + [sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g']
                     selfcal_library[target][band][vis][solint]['gaintable']=applycal_gaintable[vis]

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -22,6 +22,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
        rerank_refants = True
        refantmode = "strict"
    elif mode == "cocal":
+       rerank_refants = True
        refantmode = "strict"
    else:
        refantmode = "flex"
@@ -455,7 +456,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                                         refant=selfcal_library[target][band][vis]["refant"], refantmode=refantmode if 'inf_EB' in sint else 'flex')
                     else:
                         rerefant(vis, sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][iteration]+'.g', \
-                                refant=selfcal_library[target][band][vis]["refant"], refantmode=refantmode if 'inf_EB' in sint else 'flex')
+                                refant=selfcal_library[target][band][vis]["refant"], refantmode=refantmode if 'inf_EB' in solint else 'flex')
 
                 ##
                 ## default is to run without combine=spw for inf_EB, here we explicitly run a test inf_EB with combine='scan,spw' to determine

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -12,7 +12,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, applycal_mod
         inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp, integration_time, \
         gaincal_minsnr=2.0, minsnr_to_proceed=3.0, delta_beam_thresh=0.05, do_amp_selfcal=True, inf_EB_gaincal_combine='scan', inf_EB_gaintype='G', \
         unflag_only_lbants=False, unflag_only_lbants_onlyap=False, calonly_max_flagged=0.0, second_iter_solmode="", unflag_fb_to_prev_solint=False, \
-        rerank_refants=False, mode="selfcal", calibrators="", calculate_inf_EB_fb_anyways=False):
+        rerank_refants=False, mode="selfcal", calibrators="", calculate_inf_EB_fb_anyways=False, preapply_targets_own_inf_EB=False):
    iterjump=-1   # useful if we want to jump iterations
    sani_target=sanitize_string(target)
 
@@ -25,7 +25,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, applycal_mod
 
    if mode == "cocal":
        # Check whether there are suitable calibrators, otherwise skip this target/band.
-       include_targets, include_scans = triage_calibrators(vis, target, calibrators[band][0])
+       include_targets, include_scans = triage_calibrators(vislist[0], target, calibrators[band][0])
        if include_targets == "":
            print("No suitable calibrators found, skipping "+target)
            return
@@ -226,7 +226,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, applycal_mod
 
                     if mode == "cocal":
                         # Check which targets are acceptable to use as calibrators.
-                        targets = calibrators[band][len(solints[band] - iteration)]
+                        targets = calibrators[band][iteration - len(solints[band])]
 
                         include_targets, include_scans = triage_calibrators(vis, target, targets)
                     else:
@@ -859,7 +859,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, applycal_mod
                                  field=str(fid),spw=selfcal_library[target][band][vis]['spws'])    
                      else:
                          print('****************Removing all calibrations for '+target+' '+str(fid)+' '+band+'**************')
-                         clearcal(vis=vis,field=fid,spw=selfcal_library[target][band][vis]['spws'])
+                         clearcal(vis=vis,field=str(fid),spw=selfcal_library[target][band][vis]['spws'])
                          selfcal_library[target][band]['SNR_post']=selfcal_library[target][band]['SNR_orig'].copy()
                          selfcal_library[target][band]['RMS_post']=selfcal_library[target][band]['RMS_orig'].copy()
 

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1367,7 +1367,11 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
          # Finally, update the list of fields to be self-calibrated now that we don't need to know the list at the beginning of this solint.
          new_fields_to_selfcal = []
          for fid in selfcal_library[target][band]['sub-fields']:
-             if selfcal_library[target][band][fid][selfcal_library[target][band][fid]['vislist'][0]]["inf_EB"]["Pass"]:
-                 new_fields_to_selfcal.append(fid)
+             if mode == "cocal":
+                 if ("inf_EB" in selfcal_library[target][band][fid]['vislist'][0] and selfcal_library[target][band][fid][selfcal_library[target][band][fid]['vislist'][0]]["inf_EB"]["Pass"]) or selfcal_library[target][band][fid][selfcal_library[target][band][fid]['vislist'][0]]["inf_EB_fb"]["Pass"]:
+                     new_fields_to_selfcal.append(fid)
+             else:
+                 if selfcal_library[target][band][fid][selfcal_library[target][band][fid]['vislist'][0]]["inf_EB"]["Pass"]:
+                     new_fields_to_selfcal.append(fid)
 
          selfcal_library[target][band]['sub-fields-to-selfcal'] = new_fields_to_selfcal

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -926,7 +926,8 @@ def rank_refants(vis, caltable=None):
      tb = casatools.table()
 
      msmd.open(vis)
-     names = msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))
+     ids = msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0])
+     names = msmd.antennanames(ids)
      offset = [msmd.antennaoffset(name) for name in names]
      msmd.close()
 
@@ -947,19 +948,13 @@ def rank_refants(vis, caltable=None):
      # Calculate the number of flags for each antenna.
 
      nflags = [tb.calc('[select from '+vis+' where ANTENNA1=='+\
-             str(i)+' giving  [ntrue(FLAG)]]')['0'].sum() for i in \
-             range(len(names))]
+             str(i)+' giving  [ntrue(FLAG)]]')['0'].sum() for i in ids]
 
      # Calculate the median SNR for each antenna.
 
      if caltable != None:
-         tb.open(caltable)
-         snr = tb.getcol("SNR")
-         tb.close()
-
-         nants = len(names)
-         ordered_snr = snr.reshape(snr.shape[0:2] + (snr.shape[2]//nants, nants))
-         total_snr = ordered_snr.sum(axis=2).sum(axis=0).sum(axis=0)
+         total_snr = [tb.calc('[select from '+caltable+' where ANTENNA1=='+\
+                 str(i)+' giving  [sum(SNR)]]')['0'].sum() for i in ids]
 
      # Calculate a score based on those two.
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -854,7 +854,7 @@ def get_n_ants(vislist):
    n_ants=50.0
    for vis in vislist:
       msmd.open(vis)
-      names = msmd.antennanames()
+      names = msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))
       msmd.close()
       n_ant_vis=len(names)
       if n_ant_vis < n_ants:
@@ -867,7 +867,7 @@ def get_ant_list(vis):
    tb = casatools.table()
    n_ants=50.0
    msmd.open(vis)
-   names = msmd.antennanames()
+   names = msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))
    msmd.close()
    return names
 
@@ -878,7 +878,7 @@ def rank_refants(vis, caltable=None):
      tb = casatools.table()
 
      msmd.open(vis)
-     names = msmd.antennanames()
+     names = msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))
      offset = [msmd.antennaoffset(name) for name in names]
      msmd.close()
 
@@ -1521,7 +1521,7 @@ def get_baseline_dist(vis):
      msmd = casatools.msmetadata()
 
      msmd.open(vis)
-     names = msmd.antennanames()
+     names = msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))
      offset = [msmd.antennaoffset(name) for name in names]
      msmd.close()
      baselines=np.array([])
@@ -1865,7 +1865,7 @@ def get_flagged_solns_per_ant(gaintable,vis):
      tb = casatools.table()
 
      msmd.open(vis)
-     names = msmd.antennanames()
+     names = msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))
      offset = [msmd.antennaoffset(name) for name in names]
      msmd.close()
 
@@ -2235,7 +2235,10 @@ def render_selfcal_solint_summary_table(htmlOut,sclib,target,band,solints):
                   if key=='intflux_final':
                      line+='    <td>{:0.2f} +/- {:0.2f} mJy</td>\n'.format(sclib[target][band][vislist[len(vislist)-1]][solint]['intflux_post']*1000.0,sclib[target][band][vislist[len(vislist)-1]][solint]['e_intflux_post']*1000.0)
                   if key=='intflux_improvement':
-                     line+='    <td>{:0.2f}</td>\n'.format(sclib[target][band][vislist[len(vislist)-1]][solint]['intflux_post']/sclib[target][band][vislist[len(vislist)-1]][solint]['intflux_pre'])                      
+                     if sclib[target][band][vislist[len(vislist)-1]][solint]['intflux_pre'] == 0:
+                         line+='   <td>{:0.2f}</td>\n'.format(1.0)
+                     else:
+                         line+='   <td>{:0.2f}</td>\n'.format(sclib[target][band][vislist[len(vislist)-1]][solint]['intflux_post']/sclib[target][band][vislist[len(vislist)-1]][solint]['intflux_pre'])
                   if key=='SNR_final':
                      line+='    <td>{:0.2f}</td>\n'.format(sclib[target][band][vislist[len(vislist)-1]][solint]['SNR_post'])
                   if key=='SNR_Improvement':
@@ -2355,7 +2358,7 @@ def render_per_solint_QA_pages(sclib,solints,bands):
 
          vislist=sclib[target][band]['vislist']
          index_addition=1
-         if sclib[target][band]['final_solint'] != 'inf_ap' and sclib[target][band]['final_solint'] != 'None':
+         if sclib[target][band]['final_solint'] != solints[band][-1] and sclib[target][band]['final_solint'] != 'None':
             index_addition=2
 
          final_solint_to_plot=solints[band][final_solint_index+index_addition-1]
@@ -3193,8 +3196,8 @@ def plotcals(source):
     nants = 0
     for vis in vislist:
         msmd.open(vis)
-        if len(msmd.antennanames()) > nants:
-            nants = len(msmd.antennanames())
+        if len(msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))) > nants:
+            nants = len(msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0])))
     print(nants)
 
     for ant in range(nants):

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2225,10 +2225,13 @@ def render_selfcal_solint_summary_table(htmlOut,sclib,target,band,solints):
                if solint in vis_keys:
                   vis_solint_keys=sclib[target][band][vislist[len(vislist)-1]][solint].keys()
                   if key=='Pass':
+                    if key in sclib[target][band][vislist[len(vislist)-1]][solint]:
                      if sclib[target][band][vislist[len(vislist)-1]][solint]['Pass'] == False:
                         line+='    <td><font color="red">{}</font> {}</td>\n'.format('Fail',sclib[target][band][vislist[len(vislist)-1]][solint]['Fail_Reason'])
                      else:
                         line+='    <td><font color="blue">{}</font></td>\n'.format('Pass')
+                    else:
+                        line+='    <td><font color="green">{}</font></td>\n'.format('None')
                   if key=='intflux_final':
                      line+='    <td>{:0.2f} +/- {:0.2f} mJy</td>\n'.format(sclib[target][band][vislist[len(vislist)-1]][solint]['intflux_post']*1000.0,sclib[target][band][vislist[len(vislist)-1]][solint]['e_intflux_post']*1000.0)
                   if key=='intflux_improvement':
@@ -2391,7 +2394,11 @@ def render_per_solint_QA_pages(sclib,solints,bands):
 
 
             #must select last key for pre Jan 14th runs since they only wrote pass to the last MS dictionary entry
-            passed=sclib[target][band][vislist[len(vislist)-1]][solints[band][i]]['Pass']
+            if "Pass" in sclib[target][band][vislist[len(vislist)-1]][solints[band][i]]:
+                passed=sclib[target][band][vislist[len(vislist)-1]][solints[band][i]]['Pass']
+            else:
+                passed = 'None'
+
             '''
             if (i > final_solint_index) or ('Estimated_SNR_too_low_for_solint' not in sclib[target][band]['Stop_Reason']):
                htmlOut.writelines('<h4>Passed: <font color="red">False</font></h4>\n')
@@ -2401,7 +2408,9 @@ def render_per_solint_QA_pages(sclib,solints,bands):
             else:
                htmlOut.writelines('<h4>Passed: <font color="blue">True</font></h4>\n')
             '''
-            if passed:
+            if passed == 'None':
+               htmlOutSolint.writelines('<h4>Passed: <font color="green">N/A</font></h4>\n')
+            elif passed:
                htmlOutSolint.writelines('<h4>Passed: <font color="blue">True</font></h4>\n')
             else:
                htmlOutSolint.writelines('<h4>Passed: <font color="red">False</font></h4>\n')
@@ -2421,7 +2430,7 @@ def render_per_solint_QA_pages(sclib,solints,bands):
             htmlOutSolint.writelines('Pre Beam: {:0.2f}"x{:0.2f}" {:0.2f} deg'.format(sclib[target][band][vislist[0]][solints[band][i]]['Beam_major_pre'],sclib[target][band][vislist[0]][solints[band][i]]['Beam_minor_pre'],sclib[target][band][vislist[0]][solints[band][i]]['Beam_PA_pre'])+'<br><br>\n')
 
 
-            if solints[band][i] =='inf_EB':
+            if 'inf_EB' in solints[band][i]:
                htmlOutSolint.writelines('<h3>Phase vs. Frequency Plots:</h3>\n')
             else:
                htmlOutSolint.writelines('<h3>Phase vs. Time Plots:</h3>\n')
@@ -2437,7 +2446,7 @@ def render_per_solint_QA_pages(sclib,solints,bands):
                htmlOutSolint.writelines('N Gain solutions: {:0.0f}<br>'.format(nsols))
                htmlOutSolint.writelines('Flagged solutions: {:0.0f}<br>'.format(nflagged_sols))
                htmlOutSolint.writelines('Fraction Flagged Solutions: {:0.3f} <br><br>'.format(frac_flagged_sols))
-               if solints[band][i] =='inf_EB':
+               if 'inf_EB' in solints[band][i]:
                   if 'fallback' in sclib[target][band][vis][solints[band][i]].keys():
                      if sclib[target][band][vis][solints[band][i]]['fallback'] == '':
                         fallback_mode='None'
@@ -2450,7 +2459,7 @@ def render_per_solint_QA_pages(sclib,solints,bands):
 
                for ant in ant_list:
                   sani_target=sanitize_string(target)
-                  if solints[band][i] =='inf_EB':
+                  if 'inf_EB' in solints[band][i]:
                      xaxis='frequency'
                   else:
                      xaxis='time'
@@ -2896,3 +2905,323 @@ def unflag_failed_antennas(vis, caltable, flagged_fraction=0.25, only_long_basel
         tb.flush()
         tb.close()
         subt.close()
+
+
+
+def triage_calibrators(vis, target, potential_calibrators, max_distance=10.0, max_time=600.):
+    gaincalibrator_dict = {}
+
+    if os.path.exists(vis.replace("_target.selfcal.ms",".ms")):
+        msmd.open(vis.replace("_target.selfcal.ms",".ms"))
+
+        for field in msmd.fieldsforintent("*CALIBRATE_PHASE*"):
+            scans_for_field = msmd.scansforfield(field)
+            scans_for_gaincal = msmd.scansforintent("*CALIBRATE_PHASE*")
+            field_name = msmd.fieldnames()[field]
+            gaincalibrator_dict[field_name] = {}
+            gaincalibrator_dict[field_name]["scans"] = np.intersect1d(scans_for_field, scans_for_gaincal)
+            gaincalibrator_dict[field_name]["phasecenter"] = msmd.phasecenter(field)
+            gaincalibrator_dict[field_name]["intent"] = "phase"
+            gaincalibrator_dict[field_name]["times"] = np.array([np.mean(msmd.timesforscan(scan)) for scan in \
+                    gaincalibrator_dict[field_name]["scans"]])
+
+        gaincal_info_found = len(gaincalibrator_dict) > 0
+
+        msmd.close()
+    else:
+        gaincal_info_found = False
+
+    all_targets = potential_calibrators + [target]
+
+    msmd.open(vis)
+    targets_ids = [msmd.fieldsforname(field)[0] for field in all_targets]
+    for i, field in enumerate(targets_ids):
+        scans_for_field = msmd.scansforfield(field)
+        scans_for_science = msmd.scansforintent("*OBSERVE_TARGET*")
+        field_name = all_targets[i]
+        gaincalibrator_dict[field_name] = {}
+        gaincalibrator_dict[field_name]["scans"] = np.intersect1d(scans_for_field, scans_for_science)
+        gaincalibrator_dict[field_name]["phasecenter"] = msmd.phasecenter(field)
+        gaincalibrator_dict[field_name]["intent"] = "target" if field_name == target else "science"
+        gaincalibrator_dict[field_name]["times"] = np.array([np.mean(msmd.timesforscan(scan)) for scan in gaincalibrator_dict[field_name]["scans"]])
+
+    msmd.close()
+
+    fields = []
+    scans = []
+    distances = []
+    intents = []
+    times = []
+    import matplotlib.pyplot as plt
+    for t in gaincalibrator_dict.keys():
+        dRA = (gaincalibrator_dict[t]["phasecenter"]["m0"]["value"] - gaincalibrator_dict[target]["phasecenter"]["m0"]["value"]) * 360/(2*np.pi)
+        dDec = (gaincalibrator_dict[t]["phasecenter"]["m1"]["value"] - gaincalibrator_dict[target]["phasecenter"]["m1"]["value"]) * 360/(2*np.pi)
+        plt.plot(dRA, dDec, "ko")
+        plt.annotate(t, (dRA, dDec))
+        d = (dRA**2 + dDec**2)**0.5
+
+        scans += [gaincalibrator_dict[t]["scans"]]
+        distances += [np.repeat(d,gaincalibrator_dict[t]["scans"].size)]
+        intents += [np.repeat(gaincalibrator_dict[t]["intent"],gaincalibrator_dict[t]["scans"].size)]
+        fields += [np.repeat(t,gaincalibrator_dict[t]["scans"].size)]
+        times += [gaincalibrator_dict[t]["times"]]
+
+    times = np.concatenate(times)
+    order = np.argsort(times)
+    times = times[order]
+
+    scans = np.concatenate(scans)[order]
+    distances = np.concatenate(distances)[order]
+    intents = np.concatenate(intents)[order]
+    fields = np.concatenate(fields)[order]
+    good = np.repeat(False, scans.size)
+    case = np.repeat(0, scans.size)
+
+    if gaincal_info_found:
+        is_gaincalibrator = intents == "phase"
+        gaincal_interval = np.median(times[is_gaincalibrator][1:] - times[is_gaincalibrator][0:-1])
+        print(times[is_gaincalibrator] - times[is_gaincalibrator][0])
+    else:
+        gaincal_interval = np.inf
+    print("gaincal_interval = ", gaincal_interval)
+
+    prev_target = -1
+    prev_calibrator = -2
+    for i in range(scans.size):
+        if gaincal_info_found:
+            next_calibrator = np.where(intents[i:] == "phase")[0][0] + i
+        else:
+            next_calibrator = np.inf
+
+        if "target" in intents[i:]:
+            next_target = np.where(intents[i:] == "target")[0][0] + i
+        else:
+            next_target = scans.size
+
+        if next_calibrator == i:
+            prev_calibrator = i
+        elif next_target == i:
+            prev_target = i
+
+        """
+        if distances[i] < distances[current_calibrator] and ((current_calibrator < next_calibrator and next_calibrator > next_target) \
+                or (current_calibrator == next_calibrator)):
+            good[i] = True
+        """
+
+        #print(prev_target, prev_calibrator, next_target, next_calibrator)
+        next_target_time = times[next_target] if next_target < times.size else np.inf
+        prev_target_time = times[prev_target] if prev_target > 0 else 0
+
+        next_calibrator_distance = distances[next_calibrator] if next_calibrator < distances.size else np.inf
+        prev_calibrator_distance = distances[prev_calibrator] if prev_calibrator >= 0 else np.inf
+
+        if prev_target < prev_calibrator < next_target < next_calibrator:
+            good[i] = distances[i] < min(prev_calibrator_distance,max_distance) and \
+                    (abs(times[i] - next_target_time) < min(gaincal_interval,max_time) or \
+                    abs(times[i] - prev_target_time) < min(gaincal_interval,max_time))
+            case[i] = 1
+        elif prev_calibrator < prev_target < next_calibrator < next_target:
+            good[i] = distances[i] < min(next_calibrator_distance,max_distance) and \
+                    (abs(times[i] - prev_target_time) < min(gaincal_interval,max_time) or \
+                    abs(times[i] - next_target_time) < min(gaincal_interval,max_time))
+            case[i] = 2
+        elif prev_target < prev_calibrator < next_calibrator < next_target:
+            good[i] = (distances[i] < min(next_calibrator_distance,max_distance) and \
+                    abs(times[i] - next_target_time) < min(gaincal_interval,max_time)) or \
+                    (distances[i] < min(prev_calibrator_distance,max_distance) and \
+                    abs(times[i] - prev_target_time) < min(gaincal_interval,max_time))
+            case[i] = 3
+        elif prev_calibrator < prev_target < next_target < next_calibrator:
+            good[i] = (distances[i] < min(next_calibrator_distance,max_distance) and \
+                    abs(times[i] - next_target_time) < min(gaincal_interval,max_time)) or \
+                    (distances[i] < min(prev_calibrator_distance,max_distance) and \
+                    abs(times[i] - prev_target_time) < min(gaincal_interval,max_time))
+            case[i] = 4
+        
+
+        next_calibrator_scan = scans[next_calibrator] if gaincal_info_found else scans.size
+        prev_calibrator_scan = scans[prev_calibrator] if gaincal_info_found else -1
+        if next_target < scans.size and prev_target > 0:
+            print("{0:3d}   {1:5.2f}   {2:7s}   {3:20s}   {4:4.0f}   {5:5s}   {6:1d}   {7:3d}   {8:3d}   {9:3d}   {10:3d}".format(\
+                    scans[i], distances[i], intents[i], fields[i], times[i]-times[0], str(good[i]), case[i], prev_calibrator_scan, \
+                    next_calibrator_scan, scans[prev_target], scans[next_target]))
+        elif prev_target < 0:
+            print("{0:3d}   {1:5.2f}   {2:7s}   {3:20s}   {4:4.0f}   {5:5s}   {6:1d}   {7:3d}   {8:3d}   {9:3d}   {10:3d}".format(\
+                    scans[i], distances[i], intents[i], fields[i], times[i]-times[0], str(good[i]), case[i], prev_calibrator_scan, \
+                    next_calibrator_scan, -1, scans[next_target]))
+        else:
+            print("{0:3d}   {1:5.2f}   {2:7s}   {3:20s}   {4:4.0f}   {5:5s}   {6:1d}   {7:3d}   {8:3d}   {9:3d}   {10:3d}".format(\
+                    scans[i], distances[i], intents[i], fields[i], times[i]-times[0], str(good[i]), case[i], prev_calibrator_scan, \
+                    next_calibrator_scan, scans[prev_target], scans.max()+1))
+
+    #good = intents == "science"
+    print(scans[good].astype(str))
+    print(np.unique(fields[good]))
+
+    return ",".join(np.unique(fields[good])), ",".join(scans[good].astype(str))
+
+
+
+def make_distance_time_phaseerr_plots(vislist):
+
+    time_collection = []
+    distance_collection = []
+    rms_collection = []
+
+    for vis in vislist:
+        msmd.open(vis.replace("_target.selfcal.ms",".ms"))
+
+        gaincalibrator_dict = {}
+        for field in msmd.fieldsforintent("*CALIBRATE_PHASE*"):
+            scans_for_field = msmd.scansforfield(field)
+            scans_for_gaincal = msmd.scansforintent("*CALIBRATE_PHASE*")
+            field_name = msmd.fieldnames()[field]
+            gaincalibrator_dict[field_name] = {}
+            gaincalibrator_dict[field_name]["scans"] = np.intersect1d(scans_for_field, scans_for_gaincal)
+            gaincalibrator_dict[field_name]["phasecenter"] = msmd.phasecenter(field)
+            gaincalibrator_dict[field_name]["intent"] = "phase"
+            gaincalibrator_dict[field_name]["times"] = np.array([np.mean(msmd.timesforscan(scan)) for scan in gaincalibrator_dict[field_name]["scans"]])
+
+        #print(gaincalibrator_dict.keys())
+        gaincalibrator = list(gaincalibrator_dict.keys())[0]
+
+        msmd.close()
+
+        msmd.open(vis)
+        all_targets = [msmd.fieldnames()[i] for i in msmd.fieldsforintent("*OBSERVE_TARGET*")]
+        msmd.close()
+        #print(all_targets)
+
+        for target in all_targets:
+            #print(target)
+            if not os.path.exists(sanitize_string(target)+'_'+vis+'_Band_7_inf_1_p.g'):
+                continue
+
+            msmd.open(vis)
+            targets_ids = [msmd.fieldsforname(field)[0] for field in [target]]
+            for i, field in enumerate(targets_ids):
+                scans_for_field = msmd.scansforfield(field)
+                scans_for_science = msmd.scansforintent("*OBSERVE_TARGET*")
+                field_name = [target][i]
+                gaincalibrator_dict[field_name] = {}
+                gaincalibrator_dict[field_name]["scans"] = np.intersect1d(scans_for_field, scans_for_science)
+                gaincalibrator_dict[field_name]["phasecenter"] = msmd.phasecenter(field)
+                gaincalibrator_dict[field_name]["intent"] = "target" if field_name == target else "science"
+                gaincalibrator_dict[field_name]["times"] = np.array([np.mean(msmd.timesforscan(scan)) for scan in gaincalibrator_dict[field_name]["scans"]])
+
+            msmd.close()
+
+            fields = []
+            scans = []
+            distances = []
+            intents = []
+            times = []
+            import matplotlib.pyplot as plt
+            for t in gaincalibrator_dict.keys():
+                dRA = (gaincalibrator_dict[t]["phasecenter"]["m0"]["value"] - gaincalibrator_dict[gaincalibrator]["phasecenter"]["m0"]["value"]) * 360/(2*np.pi)
+                dDec = (gaincalibrator_dict[t]["phasecenter"]["m1"]["value"] - gaincalibrator_dict[gaincalibrator]["phasecenter"]["m1"]["value"]) * 360/(2*np.pi)
+                #plt.plot(dRA, dDec, "ko")
+                #plt.annotate(t, (dRA, dDec))
+                d = (dRA**2 + dDec**2)**0.5
+
+                scans += [gaincalibrator_dict[t]["scans"]]
+                distances += [np.repeat(d,gaincalibrator_dict[t]["scans"].size)]
+                intents += [np.repeat(gaincalibrator_dict[t]["intent"],gaincalibrator_dict[t]["scans"].size)]
+                fields += [np.repeat(t,gaincalibrator_dict[t]["scans"].size)]
+                times += [gaincalibrator_dict[t]["times"]]
+
+            times = np.concatenate(times)
+            order = np.argsort(times)
+            times = times[order]
+
+            scans = np.concatenate(scans)[order]
+            distances = np.concatenate(distances)[order]
+            intents = np.concatenate(intents)[order]
+            fields = np.concatenate(fields)[order]
+
+            nearest_calibrator_scan = np.repeat(0, scans.size)
+            time_to_calibrator = np.repeat(0.0, scans.size)
+
+            for i in range(scans.size):
+                nearest_calibrator = np.where(np.abs(times - times[i]) == np.abs(times[intents == "phase"] - times[i]).min())[0][0]
+                nearest_calibrator_scan[i] = scans[nearest_calibrator]
+
+                time_to_calibrator[i] = np.abs(times[i] - times[nearest_calibrator])
+
+                #print("{0:3d}   {1:5.2f}   {2:7s}   {3:20s}   {4:4.0f}   {5:3d}   {6:4.0f}".format(\
+                #        scans[i], distances[i], intents[i], fields[i], times[i]-times[0], nearest_calibrator_scan[i], \
+                #        time_to_calibrator[i]))
+
+
+            tb.open(sanitize_string(target)+'_'+vis+'_Band_7_inf_1_p.g')
+            cals = tb.getcol("CPARAM").flatten()
+            flags = tb.getcol("FLAG").flatten()
+            scan_numbers = tb.getcol("SCAN_NUMBER")
+            #print(scan_numbers.shape)
+            tb.close()
+
+            cals = cals[flags == False]
+            scan_numbers = scan_numbers[flags == False]
+
+            phase = np.angle(cals) * 180./np.pi
+
+            #plt.hist(phase.flatten(), 20)
+
+            for scan in np.unique(scans[intents == "target"]):
+                #time_arr = np.repeat(time_to_calibrator[scans == scan][0], (scan_numbers == scan).sum())
+                time_collection += [time_to_calibrator[scans == scan][0]]
+                distance_collection += [distances[scans == scan][0]] 
+                rms_collection += [np.std(phase[scan_numbers == scan])]
+                #plt.plot(time_arr, phase[scan_numbers == scan], "o")
+
+            del gaincalibrator_dict[target]
+
+    plt.scatter(distance_collection, time_collection, c=rms_collection)
+
+def plotcals(source):
+    import glob
+    import matplotlib.pyplot as plt
+
+    vislist = glob.glob("*.selfcal.ms")
+
+    runs = glob.glob("inf_fb*full_tclean*")
+    print(runs)
+    runs = np.array(runs)[np.array([3,0,2])]
+    #runs = np.concatenate((runs, ["original"]))
+
+    nants = 0
+    for vis in vislist:
+        msmd.open(vis)
+        if len(msmd.antennanames()) > nants:
+            nants = len(msmd.antennanames())
+    print(nants)
+
+    for ant in range(nants):
+        fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(15,5))
+
+        for run in runs:
+            for i, ax in enumerate(axes.flatten()):
+                if run == "original":
+                    tb.open(run+"/Target_"+source+"_"+vislist[i]+"_Band_7_inf_1_p.g")
+                else:
+                    tb.open(run+"/Target_"+source+"_"+vislist[i]+"_Band_7_inf_fb_6_p.g")
+
+                times = tb.getcol("TIME")
+                cals = tb.getcol("CPARAM")
+                flags = tb.getcol("FLAG")
+                antennas = tb.getcol("ANTENNA1")
+                tb.close()
+
+                phase = np.angle(cals) * 180./np.pi
+
+                good = np.logical_and(antennas == ant,  flags[0,0,:] == False)
+
+                ax.plot(times[good], phase[0,0,good], "o")
+
+        fig.tight_layout()
+
+        plt.savefig("Target_"+source+"ANT"+str(ant)+"_phase.png")
+
+        plt.clf()
+        plt.close(fig)

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1585,8 +1585,9 @@ def get_baseline_dist(vis):
      msmd = casatools.msmetadata()
 
      msmd.open(vis)
-     names = msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))
-     offset = [msmd.antennaoffset(name) for name in names]
+     ids = msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0])
+     names = msmd.antennanames(ids)
+     offset = [msmd.antennaoffset(id) for id in ids]
      msmd.close()
      baselines=np.array([])
      for i in range(len(offset)):

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2378,7 +2378,7 @@ def render_per_solint_QA_pages(sclib,solints,bands,directory='weblog'):
 
          vislist=sclib[target][band]['vislist']
          index_addition=1
-         if sclib[target][band]['final_solint'] != solints[band][-1] and sclib[target][band]['final_solint'] != 'None':
+         if sclib[target][band]['final_solint'] != solints[band][target][-1] and sclib[target][band]['final_solint'] != 'None':
             index_addition=2
          # if it's a dataset where inf_EB == inf, make sure to take out the assumption that there would be an 'inf' solution
          if 'inf' not in solints[band][target]:
@@ -2481,7 +2481,7 @@ def render_per_solint_QA_pages(sclib,solints,bands,directory='weblog'):
                htmlOutSolint.writelines('N Gain solutions: {:0.0f}<br>'.format(nsols))
                htmlOutSolint.writelines('Flagged solutions: {:0.0f}<br>'.format(nflagged_sols))
                htmlOutSolint.writelines('Fraction Flagged Solutions: {:0.3f} <br><br>'.format(frac_flagged_sols))
-               if 'inf_EB' in solints[target][band][i]:
+               if 'inf_EB' in solints[band][target][i]:
                   if 'fallback' in sclib[target][band][vis][solints[band][target][i]].keys():
                      if sclib[target][band][vis][solints[band][target][i]]['fallback'] == '':
                         fallback_mode='None'

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -3111,12 +3111,12 @@ def triage_calibrators(vis, target, potential_calibrators, max_distance=10.0, ma
     distances = []
     intents = []
     times = []
-    import matplotlib.pyplot as plt
+    #import matplotlib.pyplot as plt
     for t in gaincalibrator_dict.keys():
         dRA = (gaincalibrator_dict[t]["phasecenter"]["m0"]["value"] - gaincalibrator_dict[target]["phasecenter"]["m0"]["value"]) * 360/(2*np.pi)
         dDec = (gaincalibrator_dict[t]["phasecenter"]["m1"]["value"] - gaincalibrator_dict[target]["phasecenter"]["m1"]["value"]) * 360/(2*np.pi)
-        plt.plot(dRA, dDec, "ko")
-        plt.annotate(t, (dRA, dDec))
+        #plt.plot(dRA, dDec, "ko")
+        #plt.annotate(t, (dRA, dDec))
         d = (dRA**2 + dDec**2)**0.5
 
         scans += [gaincalibrator_dict[t]["scans"]]

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1924,7 +1924,8 @@ def get_flagged_solns_per_ant(gaintable,vis):
      tb = casatools.table()
 
      msmd.open(vis)
-     names = msmd.antennanames(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0]))
+     ids = msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*")[0])
+     names = msmd.antennanames(ids)
      offset = [msmd.antennaoffset(name) for name in names]
      msmd.close()
 
@@ -1950,11 +1951,9 @@ def get_flagged_solns_per_ant(gaintable,vis):
      os.system('cp -r '+gaintable.replace(' ','\ ')+' tempgaintable.g')
      gaintable='tempgaintable.g'
      nflags = [tb.calc('[select from '+gaintable+' where ANTENNA1=='+\
-             str(i)+' giving  [ntrue(FLAG)]]')['0'].sum() for i in \
-             range(len(names))]
+             str(i)+' giving  [ntrue(FLAG)]]')['0'].sum() for i in ids]
      nunflagged = [tb.calc('[select from '+gaintable+' where ANTENNA1=='+\
-             str(i)+' giving  [nfalse(FLAG)]]')['0'].sum() for i in \
-             range(len(names))]
+             str(i)+' giving  [nfalse(FLAG)]]')['0'].sum() for i in ids]
      os.system('rm -rf tempgaintable.g')
      fracflagged=np.array(nflags)/(np.array(nflags)+np.array(nunflagged))
      # Calculate a score based on those two.


### PR DESCRIPTION
The cocal branch adds the ability to interpolate gain solutions from bright targets that succeeded in self-calibration to faint targets that did not. When the current main of this fork merges into the original main (https://github.com/jjtobin/auto_selfcal/pull/11), this PR will move cocal onto the main branch of the development branch. Cocal will be, by default, turned off and will therefore operate in the same way as the current main would. The purpose of moving it to main is so that future developments (particularly refactoring) will include the code that makes cocal happen so that complicated merges into the cocal branch do not need to happen.