### PR TITLE
Merge user mask and model updates into refactor_code branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ TempLattice*
 .*.swp
 
 applycal_to_orig_MSes.py
+
+oussid*
+pipeline*
+flux.csv
+cont.dat
+casacalls*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Brief instructions:
 1. Create an empty directory
 2. Copy into this directory the *_target.ms files that have identical setups (targets and spectral windows) to be self-calibrated (must contain only the targets desired for self-calibration and only TARGET observation intents)
 3. Copy cont.dat file for all targets into directory (will be used to flag out spectral lines).
-4. Copy auto_selfcal.py and selfcal_helpers.py into this directory (and regenerate_weblog.py if needed)
+4. Copy all .py files in the cloned auto_selfcal repo into your working directory
 5. Run script with mpicasa -n X casa -c auto_selfcal.py; X is the number of mpi threads to use
 
 If serial operation is desired (without mpicasa), run with casa -c auto_selfcal.py

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -41,30 +41,19 @@ if len(vislist) == 0:
 spectral_average=True
 do_amp_selfcal=True
              # input as dictionary for target name to allow support of multiple targets           
-usermask=''  # require that it is a CRTF region (CASA region format)
-             # usermask={'IRAS32':'IRAS32.rgn', 'IRS5N':'IRS5N.rgn'}
+usermask={}  # require that it is a CRTF region (CASA region format)
+             # usermask={'Band_6':{'IRAS32':'IRAS32.rgn', 'IRS5N':'IRS5N.rgn'}}
              # If multiple sources and only want to use a mask for one, just specify that source.
              # The keys for remaining sources will be filled with empty strings
 
-usermodel='' # input as dictionary for target name to allow support of multiple targets
+usermodel={} # input as dictionary for target name to allow support of multiple targets
              # if includes .fits, assume a fits image, otherwise assume a CASA image
              # for spectral image, input as list i.e., usermodel=['usermodel.tt0','usermodel.tt1']
-             # usermodel={'IRAS32':['IRAS32-model.tt0','IRAS32-model.tt1'], 'IRS5N':['IRS5N-model.tt0','IRS5N-model.tt1']}
+             # usermodel={'Band_6':{'IRAS32':['IRAS32-model.tt0','IRAS32-model.tt1'], 'IRS5N':['IRS5N-model.tt0','IRS5N-model.tt1']}}
              # If multiple sources and only want to use a model for one, just specify that source.
              # The keys for remaining sources will be filled with empty strings
 
 
-if type(usermask)==dict:
-   for target in all_targets:
-      if target not in usermask.keys():
-         usermask[target]=''
-
-if type(usermodel)==dict:
-   for target in all_targets:
-      if target not in usermodel.keys():
-         usermodel[target]=''
-         
-      
 inf_EB_gaincal_combine='scan'
 inf_EB_gaintype='G'
 inf_EB_override=False
@@ -122,7 +111,8 @@ if run_findcont:
 ##
 selfcal_library, selfcal_plan, gaincalibrator_dict = prepare_selfcal(vislist, spectral_average=spectral_average, 
         sort_targets_and_EBs=sort_targets_and_EBs, scale_fov=scale_fov, inf_EB_gaincal_combine=inf_EB_gaincal_combine, 
-        inf_EB_gaintype=inf_EB_gaintype, apply_cal_mode_default=apply_cal_mode_default, do_amp_selfcal=do_amp_selfcal)
+        inf_EB_gaintype=inf_EB_gaintype, apply_cal_mode_default=apply_cal_mode_default, do_amp_selfcal=do_amp_selfcal, 
+        usermask=usermask, usermodel=usermodel)
 
 
 
@@ -144,10 +134,6 @@ for target in selfcal_library:
  sani_target=sanitize_string(target)
  for band in selfcal_library[target]:
    #make images using the appropriate tclean heuristics for each telescope
-   if usermask !='':
-      sourcemask=usermask[target]
-   else:
-      sourcemask=''
    if not os.path.exists(sani_target+'_'+band+'_dirty.image.tt0'):
       # Because tclean doesn't deal in NF masks, the automask from the initial image is likely to contain a lot of noise unless
       # we can get an estimate of the NF modifier for the auto-masking thresholds. To do this, we need to create a very basic mask
@@ -156,7 +142,7 @@ for target in selfcal_library:
                      band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold='0.0Jy',niter=1, gain=0.00001,
                      savemodel='none',parallel=parallel,
-                     field=target, mask=sourcemask, usermodel='')
+                     field=target)
 
    dirty_SNR, dirty_RMS, dirty_NF_SNR, dirty_NF_RMS = get_image_stats(sani_target+'_'+band+'_dirty.image.tt0', sani_target+'_'+band+'_dirty.mask',
             '', selfcal_library[target][band], (telescope != 'ACA' or aca_use_nfmask), 'dirty', 'dirty')
@@ -177,8 +163,7 @@ for target in selfcal_library:
                      band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold='theoretical_with_drmod',
                      savemodel='none',parallel=parallel,
-                     field=target,nfrms_multiplier=dirty_NF_RMS/dirty_RMS,
-                     mask=sourcemask, usermodel='')
+                     field=target,nfrms_multiplier=dirty_NF_RMS/dirty_RMS)
 
    initial_SNR, initial_RMS, initial_NF_SNR, initial_NF_RMS = get_image_stats(sani_target+'_'+band+'_initial.image.tt0', 
            sani_target+'_'+band+'_initial.mask', '', selfcal_library[target][band], (telescope != 'ACA' or aca_use_nfmask), 'orig', 'orig')
@@ -236,15 +221,11 @@ if check_all_spws:
             if spw not in keylist:
                selfcal_library[target][band]['per_spw_stats'][spw]={}
             if not os.path.exists(sani_target+'_'+band+'_'+str(spw)+'_dirty.image.tt0'):
-               if usermask !='':
-                  sourcemask=usermask[target]
-               else:
-                  sourcemask=''
                tclean_wrapper(selfcal_library[target][band],sani_target+'_'+band+'_'+str(spw)+'_dirty',
                      band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold='0.0Jy',niter=1,gain=0.00001,
                      savemodel='none',parallel=parallel,
-                     field=target,spw=spw,mask=sourcemask,usermodel='')
+                     field=target,spw=spw)
 
             dirty_SNR, dirty_RMS, dirty_per_spw_NF_SNR, dirty_per_spw_NF_RMS = get_image_stats(sani_target+'_'+band+'_'+str(spw)+
                     '_dirty.image.tt0', sani_target+'_'+band+'_'+str(spw)+'_dirty.mask','', selfcal_library[target][band], 
@@ -255,7 +236,7 @@ if check_all_spws:
                           band,telescope=telescope,nsigma=4.0, threshold='theoretical_with_drmod',scales=[0],\
                           savemodel='none',parallel=parallel,\
                           field=target,datacolumn='corrected',\
-                          spw=spw,nfrms_multiplier=dirty_per_spw_NF_RMS/dirty_RMS,mask=sourcemask,usermodel='')
+                          spw=spw,nfrms_multiplier=dirty_per_spw_NF_RMS/dirty_RMS)
 
             per_spw_SNR, per_spw_RMS, initial_per_spw_NF_SNR, initial_per_spw_NF_RMS = get_image_stats(sani_target+'_'+band+'_'+str(spw)+
                     '_initial.image.tt0', sani_target+'_'+band+'_'+str(spw)+'_initial.mask', '', selfcal_library[target][band], 
@@ -297,21 +278,13 @@ with open('selfcal_library.pickle', 'wb') as handle:
 ##
 for target in selfcal_library:
  for band in selfcal_library[target].keys():
-   if usermask !='':
-      sourcemask=usermask[target]
-   else:
-      sourcemask=''
-   if usermodel !='':
-      sourcemodel=usermodel[target]
-   else:
-      sourcemodel=''
    run_selfcal(selfcal_library[target][band], selfcal_plan[target][band], target, band, telescope, n_ants, \
            gaincal_minsnr=gaincal_minsnr, gaincal_unflag_minsnr=gaincal_unflag_minsnr, minsnr_to_proceed=minsnr_to_proceed, delta_beam_thresh=delta_beam_thresh, do_amp_selfcal=do_amp_selfcal, \
            inf_EB_gaincal_combine=inf_EB_gaincal_combine, inf_EB_gaintype=inf_EB_gaintype, unflag_only_lbants=unflag_only_lbants, \
            unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, \
            second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, rerank_refants=rerank_refants, \
            gaincalibrator_dict=gaincalibrator_dict, allow_gain_interpolation=allow_gain_interpolation, guess_scan_combine=guess_scan_combine, \
-           aca_use_nfmask=aca_use_nfmask,mask=sourcemask,usermodel=sourcemodel)
+           aca_use_nfmask=aca_use_nfmask)
 
 print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 
@@ -448,17 +421,13 @@ if allow_cocal:
 ##
 for target in selfcal_library:
  sani_target=sanitize_string(target)
- if usermask !='':
-    sourcemask=usermask[target]
- else:
-    sourcemask=''
  for band in selfcal_library[target].keys():
    nfsnr_modifier = selfcal_library[target][band]['RMS_NF_curr'] / selfcal_library[target][band]['RMS_curr']
    tclean_wrapper(selfcal_library[target][band],sani_target+'_'+band+'_final',\
                band,telescope=telescope,nsigma=3.0, threshold=str(selfcal_library[target][band]['RMS_NF_curr']*3.0)+'Jy',scales=[0],\
                savemodel='none',parallel=parallel,
                field=target,datacolumn='corrected',\
-               nfrms_multiplier=nfsnr_modifier,mask=sourcemask,usermodel='')
+               nfrms_multiplier=nfsnr_modifier)
 
    final_SNR, final_RMS, final_NF_SNR, final_NF_RMS = get_image_stats(sani_target+'_'+band+'_final.image.tt0', sani_target+'_'+band+'_final.mask',
            '', selfcal_library[target][band], (telescope !='ACA' or aca_use_nfmask), 'final', 'final')
@@ -502,10 +471,6 @@ print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 if check_all_spws:
    for target in selfcal_library:
       sani_target=sanitize_string(target)
-      if usermask !='':
-         sourcemask=usermask[target]
-      else:
-         sourcemask=''
       for band in selfcal_library[target].keys():
          selfcal_library[target][band]['vislist']=selfcal_library[target][band]['vislist'].copy()
 
@@ -519,7 +484,7 @@ if check_all_spws:
                           band,telescope=telescope,nsigma=4.0, threshold='theoretical',scales=[0],\
                           savemodel='none',parallel=parallel,\
                           field=target,datacolumn='corrected',\
-                          spw=spw,nfrms_multiplier=nfsnr_modifier,mask=sourcemask,usermodel='')
+                          spw=spw,nfrms_multiplier=nfsnr_modifier)
 
             final_per_spw_SNR, final_per_spw_RMS, final_per_spw_NF_SNR, final_per_spw_NF_RMS = get_image_stats(
                     sani_target+'_'+band+'_'+str(spw)+'_final.image.tt0', sani_target+'_'+band+'_'+str(spw)+'_final.mask',

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -80,8 +80,20 @@ apply_to_target_ms=False # apply final selfcal solutions back to the input _targ
 sort_targets_and_EBs=False
 run_findcont=True
 
+if run_findcont and os.path.exists("cont.dat"):
+    if np.any([len(parse_contdotdat('cont.dat',target)) == 0 for target in all_targets]):
+        if not os.path.exists("cont.dat.original"):
+            print("Found existing cont.dat, but it is missing targets. Backing that up to cont.dat.original")
+            os.system("mv cont.dat cont.dat.original")
+        else:
+            print("Found existing cont.dat, but it is missing targets. A backup of the original (cont.dat.original) already exists, so not backing up again.")
+    elif run_findcont:
+        print("cont.dat already exists and includes all targets, so running findcont is not needed. Continuing...")
+        run_findcont=False
+
 if run_findcont:
     try:
+        print("Running findcont")
         h_init()
         hifa_importdata(vis=vislist, dbservice=False)
         hif_checkproductsize(maxcubesize=60.0, maxcubelimit=70.0, maxproductsize=4000.0)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -12,8 +12,13 @@ import sys
 sys.path.append("./")
 from selfcal_helpers import *
 from run_selfcal import run_selfcal
-from casampi.MPIEnvironment import MPIEnvironment 
-parallel=MPIEnvironment.is_mpi_enabled
+
+# Mac builds of CASA lack MPI and error without this try/except
+try:
+   from casampi.MPIEnvironment import MPIEnvironment   
+   parallel=MPIEnvironment.is_mpi_enabled
+except:
+   parallel=False
 
 ###################################################################################################
 ######################## All code until line ~170 is just jumping through hoops ###################

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -55,12 +55,17 @@ do_amp_selfcal=True
              # input as dictionary for target name to allow support of multiple targets           
 usermask=''  # require that it is a CRTF region (CASA region format)
              # usermask={'IRAS32':'IRAS32.rgn', 'IRS5N':'IRS5N.rgn'}
+             # If multiple sources and only want to use a mask for one, just specify that source.
+             # The keys for remaining sources will be filled with empty strings
+
 usermodel='' # input as dictionary for target name to allow support of multiple targets
              # if includes .fits, assume a fits image, otherwise assume a CASA image
              # for spectral image, input as list i.e., usermodel=['usermodel.tt0','usermodel.tt1']
              # usermodel={'IRAS32':['IRAS32-model.tt0','IRAS32-model.tt1'], 'IRS5N':['IRS5N-model.tt0','IRS5N-model.tt1']}
-usermask={'IRAS32':'IRAS32.rgn', 'IRS5N':''}
-usermodel={'IRAS32':['IRAS32-model-sub.tt0','IRAS32-model-sub.tt1'], 'IRS5N':['IRS5N-model-sub.tt0','IRS5N-model-sub.tt1']
+             # If multiple sources and only want to use a model for one, just specify that source.
+             # The keys for remaining sources will be filled with empty strings
+
+
 if type(usermask)==dict:
    for target in all_targets:
       if target not in usermask.keys():

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -79,7 +79,7 @@ dividing_factor=-99.0  # number that the peak SNR is divided by to determine fir
 check_all_spws=False   # generate per-spw images to check phase transfer did not go poorly for narrow windows
 apply_to_target_ms=False # apply final selfcal solutions back to the input _target.ms files
 sort_targets_and_EBs=False
-run_findcont=True
+run_findcont=False
 
 if run_findcont and os.path.exists("cont.dat"):
     if np.any([len(parse_contdotdat('cont.dat',target)) == 0 for target in all_targets]):

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -811,8 +811,12 @@ for target in all_targets:
  for band in selfcal_library[target].keys():
    if usermask !='':
       sourcemask=usermask[target]
+   else:
+      sourcemask=''
    if usermodel !='':
       sourcemodel=usermodel[target]
+   else:
+      sourcemodel=''
    run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_per_field, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize[target], imsize[target], \
            inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp[target], integration_time, spectral_scan, spws_set,\
            gaincal_minsnr=gaincal_minsnr, gaincal_unflag_minsnr=gaincal_unflag_minsnr, minsnr_to_proceed=minsnr_to_proceed, delta_beam_thresh=delta_beam_thresh, do_amp_selfcal=do_amp_selfcal, \
@@ -833,7 +837,10 @@ print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 ##
 for target in all_targets:
  sani_target=sanitize_string(target)
- sourcemask=usermask[target]
+ if usermask !='':
+    sourcemask=usermask[target]
+ else:
+    sourcemask=''
  for band in selfcal_library[target].keys():
    vislist=selfcal_library[target][band]['vislist'].copy()
    nfsnr_modifier = selfcal_library[target][band]['RMS_NF_curr'] / selfcal_library[target][band]['RMS_curr']

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -564,10 +564,11 @@ for target in all_targets:
    selfcal_library[target][band]['Beam_major_orig']=header['restoringbeam']['major']['value']
    selfcal_library[target][band]['Beam_minor_orig']=header['restoringbeam']['minor']['value']
    selfcal_library[target][band]['Beam_PA_orig']=header['restoringbeam']['positionangle']['value'] 
-   if initial_tclean_return['iterdone'] > 0 and 'VLA' in telescope:
-      selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
-   elif 'VLA' in telescope:
-      selfcal_library[target][band]['clean_threshold_orig']=4.0*initial_RMS
+   if 'VLA' in telescope:
+       if initial_tclean_return['iterdone'] > 0:
+          selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
+       else:
+          selfcal_library[target][band]['clean_threshold_orig']=4.0*initial_RMS
    goodMask=checkmask(imagename=sani_target+'_'+band+'_initial.image.tt0')
    if goodMask:
       selfcal_library[target][band]['intflux_orig'],selfcal_library[target][band]['e_intflux_orig']=get_intflux(sani_target+'_'+band+'_initial.image.tt0',initial_RMS)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -452,7 +452,7 @@ for target in all_targets:
             sensitivity=sensitivity   #*4.0  might be unnecessary with DR mods
       else:
          sensitivity=0.0
-      tclean_wrapper(vislist,sani_target+'_'+band+'_initial',
+      initial_tclean_return = tclean_wrapper(vislist,sani_target+'_'+band+'_initial',
                      band_properties,band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold=str(sensitivity*4.0)+'Jy',
                      savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],nterms=nterms[target][band],
@@ -483,9 +483,7 @@ for target in all_targets:
       selfcal_library[target][band]['clean_threshold_orig']=sensitivity*4.0
    if 'VLA' in telescope:
       selfcal_library[target][band]['theoretical_sensitivity']=-99.0
-      with open(sani_target+'_'+band+'_initial.return.pickle', 'rb') as handle:
-          initial_tclean_return = pickle.load(handle)
-          selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
+      selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
    selfcal_library[target][band]['SNR_orig']=initial_SNR
    if selfcal_library[target][band]['nterms'] == 1:  # updated nterms if needed based on S/N and fracbw
       selfcal_library[target][band]['nterms']=check_image_nterms(selfcal_library[target][band]['fracbw'],selfcal_library[target][band]['SNR_orig'])

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -78,7 +78,7 @@ dividing_factor=-99.0  # number that the peak SNR is divided by to determine fir
 check_all_spws=False   # generate per-spw images to check phase transfer did not go poorly for narrow windows
 apply_to_target_ms=False # apply final selfcal solutions back to the input _target.ms files
 sort_targets_and_EBs=False
-run_findcont=True
+run_findcont=False
 
 if run_findcont and os.path.exists("cont.dat"):
     if np.any([len(parse_contdotdat('cont.dat',target)) == 0 for target in all_targets]):

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -93,6 +93,11 @@ if run_findcont and os.path.exists("cont.dat"):
 
 if run_findcont:
     try:
+        if 'pipeline' not in sys.modules:
+            print("Pipeline found but not imported. Importing...")
+            import pipeline
+            pipeline.initcli()
+
         print("Running findcont")
         h_init()
         hifa_importdata(vis=vislist, dbservice=False)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -483,7 +483,7 @@ for target in all_targets:
       selfcal_library[target][band]['clean_threshold_orig']=sensitivity*4.0
    if 'VLA' in telescope:
       selfcal_library[target][band]['theoretical_sensitivity']=-99.0
-      with open('Target_K04169_Band_6_initial.return.pickle', 'rb') as handle:
+      with open(sani_target+'_'+band+'_initial.return.pickle', 'rb') as handle:
           initial_tclean_return = pickle.load(handle)
           selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
    selfcal_library[target][band]['SNR_orig']=initial_SNR

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -109,6 +109,7 @@ check_all_spws=False   # generate per-spw images to check phase transfer did not
 apply_to_target_ms=False # apply final selfcal solutions back to the input _target.ms files
 sort_targets_and_EBs=False
 run_findcont=False
+debug=False
 
 if run_findcont and os.path.exists("cont.dat"):
     if np.any([len(parse_contdotdat('cont.dat',target)) == 0 for target in all_targets]):
@@ -289,7 +290,8 @@ for target in all_targets:
               selfcal_library[target][band][fid][vis] = {}
 
 import json
-print(json.dumps(selfcal_library, indent=4))
+if debug:
+    print(json.dumps(selfcal_library, indent=4))
 ##
 ## finds solints, starting with inf, ending with int, and tries to align
 ## solints with number of integrations
@@ -450,8 +452,8 @@ for target in all_targets:
       if selfcal_library[target][band]['Total_TOS'] == 0.0:
          selfcal_library[target].pop(band)
 
-
-print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
+if debug:
+    print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 ##
 ## create initial images for each target to evaluate SNR and beam
 ## replicates what a preceding hif_makeimages would do
@@ -598,8 +600,8 @@ for target in all_targets:
           selfcal_library[target][band][fid]['intflux_orig'],selfcal_library[target][band][fid]['e_intflux_orig']=-99.0,-99.0
 
 
-
-print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
+if debug:
+    print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 ####MAKE DIRTY PER SPW IMAGES TO PROPERLY ASSESS DR MODIFIERS
 ##
 ## Make a initial image per spw images to assess overall improvement
@@ -863,8 +865,8 @@ for target in all_targets:
            second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, rerank_refants=rerank_refants, \
            gaincalibrator_dict=gaincalibrator_dict, allow_gain_interpolation=allow_gain_interpolation, guess_scan_combine=guess_scan_combine, \
            aca_use_nfmask=aca_use_nfmask,mask=sourcemask,usermodel=sourcemodel)
-
-print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
+if debug:
+    print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 ##
 ## If we want to try amplitude selfcal, should we do it as a function out of the main loop or a separate loop?
 ## Mechanics are likely to be a bit more simple since I expect we'd only try a single solint=inf solution
@@ -983,8 +985,8 @@ for target in all_targets:
 
 
 
-
-print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
+if debug:
+    print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 
 ##
 ## Make a final image per spw images to assess overall improvement

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -811,7 +811,7 @@ for target in all_targets:
    if selfcal_library[target][band]['clean_threshold_orig'] < selfcal_library[target][band]['RMS_NF_curr']*3.0:
        print("WARNING: The clean threshold used for the initial image was less than 3*RMS_NF_curr, using that for the final image threshold instead.")
    tclean_wrapper(vislist,sani_target+'_'+band+'_final',\
-               band_properties,band,telescope=telescope,nsigma=3.0, threshold=str(clean_threshold*3.0)+'Jy',scales=[0],\
+               band_properties,band,telescope=telescope,nsigma=3.0, threshold=str(clean_threshold)+'Jy',scales=[0],\
                savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],
                nterms=selfcal_library[target][band]['nterms'],field=target,datacolumn='corrected',spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], \
                nfrms_multiplier=nfsnr_modifier, image_mosaic_fields_separately=selfcal_library[target][band]['obstype']=='mosaic', \

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -430,6 +430,8 @@ for target in all_targets:
    #make images using the appropriate tclean heuristics for each telescope
    if usermask !='':
       sourcemask=usermask[target]
+   else:
+      sourcemask=''
    if not os.path.exists(sani_target+'_'+band+'_dirty.image.tt0'):
       # Because tclean doesn't deal in NF masks, the automask from the initial image is likely to contain a lot of noise unless
       # we can get an estimate of the NF modifier for the auto-masking thresholds. To do this, we need to create a very basic mask

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -78,6 +78,18 @@ dividing_factor=-99.0  # number that the peak SNR is divided by to determine fir
 check_all_spws=False   # generate per-spw images to check phase transfer did not go poorly for narrow windows
 apply_to_target_ms=False # apply final selfcal solutions back to the input _target.ms files
 sort_targets_and_EBs=False
+run_findcont=True
+
+if run_findcont:
+    try:
+        h_init()
+        hifa_importdata(vis=vislist, dbservice=False)
+        hif_checkproductsize(maxcubesize=60.0, maxcubelimit=70.0, maxproductsize=4000.0)
+        hif_makeimlist(specmode="mfs")
+        hif_findcont()
+    except:
+        print("\nWARNING: Cannot run findcont as the pipeline was not found. Please retry with a CASA version that includes the pipeline or start CASA with the --pipeline flag.\n")
+        sys.exit(0)
 
 if sort_targets_and_EBs:
     all_targets.sort()

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -564,9 +564,9 @@ for target in all_targets:
    selfcal_library[target][band]['Beam_major_orig']=header['restoringbeam']['major']['value']
    selfcal_library[target][band]['Beam_minor_orig']=header['restoringbeam']['minor']['value']
    selfcal_library[target][band]['Beam_PA_orig']=header['restoringbeam']['positionangle']['value'] 
-   if initial_tclean_return['iterdone'] > 0:
+   if initial_tclean_return['iterdone'] > 0 and 'VLA' in telescope:
       selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
-   else:
+   elif 'VLA' in telescope:
       selfcal_library[target][band]['clean_threshold_orig']=4.0*initial_RMS
    goodMask=checkmask(imagename=sani_target+'_'+band+'_initial.image.tt0')
    if goodMask:

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -47,17 +47,20 @@ if len(vislist) == 0:
 spectral_average=True
 do_amp_selfcal=True
              # input as dictionary for target name to allow support of multiple targets           
-usermask={}  # require that it is a CRTF region (CASA region format)
-             # usermask={'Band_6':{'IRAS32':'IRAS32.rgn', 'IRS5N':'IRS5N.rgn'}}
+usermask={'AS_205A':{'Band_8':'AS_205A.rgn'}}  # require that it is a CRTF region (CASA region format)
+             # usermask={'IRAS32':{'Band_6':'IRAS32.rgn'}, 'IRS5N':{'Band_6': 'IRS5N.rgn'}}
              # If multiple sources and only want to use a mask for one, just specify that source.
              # The keys for remaining sources will be filled with empty strings
+             # NOTE THE DICTIONARY HEIRARCHY HAS CHANGED FROM PREVIOUS VERSION, NOW IT IS [TARGET][BAND] INSTEAD OF [BAND][TARGET]
 
-usermodel={} # input as dictionary for target name to allow support of multiple targets
+usermodel={'AS_205A':{'Band_8':['AS_205A.model.tt0']}} 
+             # input as dictionary for target name to allow support of multiple targets
              # if includes .fits, assume a fits image, otherwise assume a CASA image
              # for spectral image, input as list i.e., usermodel=['usermodel.tt0','usermodel.tt1']
-             # usermodel={'Band_6':{'IRAS32':['IRAS32-model.tt0','IRAS32-model.tt1'], 'IRS5N':['IRS5N-model.tt0','IRS5N-model.tt1']}}
+             # usermodel={'IRAS32':{'Band_6':['IRAS32-model.tt0','IRAS32-model.tt1']}, 'IRS5N':{'Band_6'['IRS5N-model.tt0','IRS5N-model.tt1']}}
              # If multiple sources and only want to use a model for one, just specify that source.
              # The keys for remaining sources will be filled with empty strings
+             # NOTE THE DICTIONARY HEIRARCHY HAS CHANGED FROM PREVIOUS VERSION, NOW IT IS [TARGET][BAND] INSTEAD OF [BAND][TARGET]
 
 
 inf_EB_gaincal_combine='scan'
@@ -124,10 +127,13 @@ if run_findcont:
 selfcal_library, selfcal_plan, gaincalibrator_dict = prepare_selfcal(vislist, spectral_average=spectral_average, 
         sort_targets_and_EBs=sort_targets_and_EBs, scale_fov=scale_fov, inf_EB_gaincal_combine=inf_EB_gaincal_combine, 
         inf_EB_gaintype=inf_EB_gaintype, apply_cal_mode_default=apply_cal_mode_default, do_amp_selfcal=do_amp_selfcal, 
-        usermask=usermask, usermodel=usermodel)
+        usermask=usermask, usermodel=usermodel,debug=debug)
 
 
-
+with open('selfcal_library.pickle', 'wb') as handle:
+    pickle.dump(selfcal_library, handle, protocol=pickle.HIGHEST_PROTOCOL)
+with open('selfcal_plan.pickle', 'wb') as handle:
+    pickle.dump(selfcal_plan, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 ###################################################################################################
@@ -173,7 +179,7 @@ for target in selfcal_library:
                   band,telescope=telescope,nsigma=4.0, scales=[0],
                   threshold='theoretical_with_drmod',
                   savemodel='none',parallel=parallel,
-                  field=target,nfrms_multiplier=dirty_NF_RMS/dirty_RMS)
+                  field=target,nfrms_multiplier=dirty_NF_RMS/dirty_RMS,store_threshold='orig')
 
    initial_SNR, initial_RMS, initial_NF_SNR, initial_NF_RMS = get_image_stats(sani_target+'_'+band+'_initial.image.tt0', 
            sani_target+'_'+band+'_initial.mask', '', selfcal_library[target][band], (telescope != 'ACA' or aca_use_nfmask), 'orig', 'orig')

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -47,13 +47,13 @@ if len(vislist) == 0:
 spectral_average=True
 do_amp_selfcal=True
              # input as dictionary for target name to allow support of multiple targets           
-usermask={'AS_205A':{'Band_8':'AS_205A.rgn'}}  # require that it is a CRTF region (CASA region format)
+usermask={}  # require that it is a CRTF region (CASA region format)
              # usermask={'IRAS32':{'Band_6':'IRAS32.rgn'}, 'IRS5N':{'Band_6': 'IRS5N.rgn'}}
              # If multiple sources and only want to use a mask for one, just specify that source.
              # The keys for remaining sources will be filled with empty strings
              # NOTE THE DICTIONARY HEIRARCHY HAS CHANGED FROM PREVIOUS VERSION, NOW IT IS [TARGET][BAND] INSTEAD OF [BAND][TARGET]
 
-usermodel={'AS_205A':{'Band_8':['AS_205A.model.tt0']}} 
+usermodel={} 
              # input as dictionary for target name to allow support of multiple targets
              # if includes .fits, assume a fits image, otherwise assume a CASA image
              # for spectral image, input as list i.e., usermodel=['usermodel.tt0','usermodel.tt1']

--- a/prepare_selfcal.py
+++ b/prepare_selfcal.py
@@ -109,6 +109,24 @@ def prepare_selfcal(vislist,
           else:
              selfcal_library[target][band]['obstype']='single-point'
 
+          # Fill in the usermask and usermodel, if supplied.
+
+          if target in usermask:
+              if band in usermask[target]:
+                  selfcal_library[target][band]['usermask'] = usermask[target][band]
+              else:
+                  selfcal_library[target][band]['usermask'] = ''
+          else:
+              selfcal_library[target][band]['usermask'] = ''
+
+          if target in usermodel:
+              if band in usermodel[target]:
+                  selfcal_library[target][band]['usermodel'] = usermodel[target][band]
+              else:
+                  selfcal_library[target][band]['usermodel'] = ''
+          else:
+              selfcal_library[target][band]['usermodel'] = ''
+
           # Make sure the fields get mapped properly, in case the order in which they are observed changes from EB to EB.
 
           selfcal_library[target][band]['sub-fields-fid_map'] = {}

--- a/prepare_selfcal.py
+++ b/prepare_selfcal.py
@@ -12,7 +12,10 @@ def prepare_selfcal(vislist,
         inf_EB_gaincal_combine='scan',
         inf_EB_gaintype='G',
         apply_cal_mode_default='calflag',
-        do_amp_selfcal=True):
+        do_amp_selfcal=True,
+        usermask={},
+        usermodel={},
+        debug=False):
 
     n_ants=get_n_ants(vislist)
     telescope=get_telescope(vislist[0])

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -137,7 +137,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
 
          nfsnr_modifier = selfcal_library['RMS_NF_curr'] / selfcal_library['RMS_curr']
          #remove mask if exists from previous selfcal _post image user is specifying a mask
-         if os.path.exists(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.mask') and mask != '':
+         if os.path.exists(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.mask') and selfcal_library['usermask'] != '':
             os.system('rm -rf '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.mask')
          tclean_wrapper(selfcal_library,sani_target+'_'+band+'_'+solint+'_'+str(iteration),
                      band,telescope=telescope,nsigma=selfcal_library['nsigma'][iteration], scales=[0],

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1199,12 +1199,18 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                  else:
                      print('FIELD: '+str(fid)+', REASON: Failed earlier solint')
              print('****************Reapplying previous solint solutions where available*************')
+
              #if the final successful solint was inf_EB but inf_EB had a S/N decrease, don't count it as a success and revert to no selfcal
              if selfcal_library[target][band]['final_solint'] == 'inf_EB' and selfcal_library[target][band]['inf_EB_SNR_decrease']:
                 selfcal_library[target][band]['SC_success']=False
+                selfcal_library[target][band]['final_solint']='None'
+                for vis in vislist:
+                   selfcal_library[target][band][vis]['inf_EB']['Pass']=False    #  remove the success from inf_EB
                 for fid in np.intersect1d(selfcal_library[target][band]['sub-fields'],list(selfcal_library[target][band]['sub-fields-fid_map'][vis].keys())):
                    if selfcal_library[target][band][fid]['final_solint'] == 'inf_EB' and selfcal_library[target][band][fid]['inf_EB_SNR_decrease']:
                       selfcal_library[target][band][fid]['SC_success']=False
+                      for vis in vislist:
+                         selfcal_library[target][band][fid][vis]['inf_EB']['Pass']=False    #  remove the success from inf_EB
 
              for vis in vislist:
                  flagmanager(vis=vis,mode='restore',versionname='selfcal_starting_flags_'+sani_target)

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1244,7 +1244,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                 for fid in selfcal_library[target][band]['sub-fields-to-selfcal']:
                     print('Field '+str(fid)+' Was: ',solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]])
                     get_SNR_self_update([target],band,vislist,selfcal_library[target][band][fid],n_ants,solint,solints[band][target][iteration+1],integration_time,solint_snr_per_field[target][band][fid])
-                    print('FIeld '+str(fid)+' Now: ',solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]])
+                    print('Field '+str(fid)+' Now: ',solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]])
 
              # If not all fields succeed for inf_EB or scan_inf/inf, depending on mosaic or single field, then don't go on to amplitude selfcal,
              # even if *some* fields succeeded.

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -16,7 +16,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
         gaincal_minsnr=2.0, gaincal_unflag_minsnr=5.0, minsnr_to_proceed=3.0, delta_beam_thresh=0.05, do_amp_selfcal=True, inf_EB_gaincal_combine='scan', inf_EB_gaintype='G', \
         unflag_only_lbants=False, unflag_only_lbants_onlyap=False, calonly_max_flagged=0.0, second_iter_solmode="", unflag_fb_to_prev_solint=False, \
         rerank_refants=False, mode="selfcal", calibrators="", calculate_inf_EB_fb_anyways=False, preapply_targets_own_inf_EB=False, \
-        gaincalibrator_dict={}, allow_gain_interpolation=False, guess_scan_combine=False, aca_use_nfmask=False, mask='', usermodel=''):
+        gaincalibrator_dict={}, allow_gain_interpolation=False, guess_scan_combine=False, aca_use_nfmask=False):
 
    # If we are running this on a mosaic, we want to rerank reference antennas and have a higher gaincal_minsnr by default.
 
@@ -50,14 +50,14 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
            selfcal_library['Stop_Reason'] += '; No suitable co-calibrators'
            return
 
-   if usermodel != '':
+   if selfcal_library['usermodel'] != '':
       print('Setting model column to user model')
       usermodel_wrapper(selfcal_library,sani_target+'_'+band,
                      band,telescope=telescope,nsigma=0.0, scales=[0],
                      threshold='0.0Jy',
                      savemodel='modelcolumn',parallel=parallel,
                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],resume=False, 
-                     cyclefactor=selfcal_library[target][band]['cyclefactor'],mask=mask,usermodel=usermodel)
+                     cyclefactor=selfcal_library[target][band]['cyclefactor'])
 
    print('Starting selfcal procedure on: '+target+' '+band)
 
@@ -138,7 +138,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                      band,telescope=telescope,nsigma=selfcal_library['nsigma'][iteration], scales=[0],
                      threshold=str(selfcal_library['nsigma'][iteration]*selfcal_library['RMS_NF_curr'])+'Jy',
                      savemodel='none',parallel=parallel,
-                     field=target, nfrms_multiplier=nfsnr_modifier, resume=resume, mask=mask, usermodel=usermodel)
+                     field=target, nfrms_multiplier=nfsnr_modifier, resume=resume)
 
          # Check that a mask was actually created, because if not the model will be empty and gaincal will do bad things and the 
          # code will break.
@@ -169,7 +169,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                              band,telescope=telescope,nsigma=selfcal_library['nsigma'][iteration], scales=[0],
                              threshold=str(selfcal_library['nsigma'][iteration]*selfcal_library['RMS_NF_curr'])+'Jy',
                              savemodel='modelcolumn',parallel=parallel,
-                             field=target, nfrms_multiplier=nfsnr_modifier, savemodel_only=True, mask=mask, usermodel=usermodel)
+                             field=target, nfrms_multiplier=nfsnr_modifier, savemodel_only=True)
 
              for vis in vislist:
                 # Record gaincal details.
@@ -224,7 +224,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                       band,telescope=telescope,nsigma=selfcal_library['nsigma'][iteration], scales=[0],
                       threshold=str(selfcal_library['nsigma'][iteration]*selfcal_library['RMS_NF_curr'])+'Jy',
                       savemodel='none',parallel=parallel,
-                      field=target, nfrms_multiplier=nfsnr_modifier, mask=mask, usermodel=usermodel)
+                      field=target, nfrms_multiplier=nfsnr_modifier)
 
              ##
              ## Do the assessment of the post- (and pre-) selfcal images.
@@ -334,7 +334,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                           band,telescope=telescope,nsigma=selfcal_library['nsigma'][iteration], scales=[0],
                           threshold=str(selfcal_library[vislist[0]][solint]['clean_threshold'])+'Jy',
                           savemodel='none',parallel=parallel,
-                          field=target, nfrms_multiplier=nfsnr_modifier, image_mosaic_fields_separately=False, mask=mask, usermodel=usermodel)
+                          field=target, nfrms_multiplier=nfsnr_modifier, image_mosaic_fields_separately=False)
 
                  ##
                  ## Do the assessment of the post- (and pre-) selfcal images.

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -5,8 +5,12 @@ import sys
 #execfile('selfcal_helpers.py',globals())
 sys.path.append("./")
 from selfcal_helpers import *
-from casampi.MPIEnvironment import MPIEnvironment 
-parallel=MPIEnvironment.is_mpi_enabled
+# Mac builds of CASA lack MPI and error without this try/except
+try:
+   from casampi.MPIEnvironment import MPIEnvironment   
+   parallel=MPIEnvironment.is_mpi_enabled
+except:
+   parallel=False
 
 def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_per_field, applycal_mode, solmode, band_properties, telescope, n_ants, cellsize, imsize, \
         inf_EB_gaintype_dict, inf_EB_gaincal_combine_dict, inf_EB_fallback_mode_dict, gaincal_combine, applycal_interp, integration_time, spectral_scan, spws_set, \

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy 
 import scipy.stats
 import scipy.signal
-import pickle
 import math
 import os
 
@@ -147,9 +146,6 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                startmodel=startmodel,
                datacolumn=datacolumn,spw=spw,wprojplanes=wprojplanes, verbose=True)
 
-        with open(imagename+'.return.pickle', 'wb') as handle:
-            pickle.dump(tclean_return, handle, protocol=pickle.HIGHEST_PROTOCOL)
-
         if image_mosaic_fields_separately:
             for field_id in mosaic_field_phasecenters:
                 if 'VLA' in telescope:
@@ -243,6 +239,8 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                  parallel=False,
                  phasecenter=phasecenter,spw=spw,wprojplanes=wprojplanes)
     
+    if not savemodel_only:
+        return tclean_return
 
 
 def collect_listobs_per_vis(vislist):

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2,6 +2,7 @@ import numpy as np
 import numpy 
 import scipy.stats
 import scipy.signal
+import pickle
 import math
 import os
 
@@ -110,7 +111,7 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
         if not resume:
             for ext in ['.image*', '.mask', '.model*', '.pb*', '.psf*', '.residual*', '.sumwt*','.gridwt*']:
                 os.system('rm -rf '+ imagename + ext)
-        tclean(vis= vis, 
+        tclean_return = tclean(vis= vis, 
                imagename = imagename, 
                field=field,
                specmode = 'mfs', 
@@ -145,6 +146,9 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                phasecenter=phasecenter,
                startmodel=startmodel,
                datacolumn=datacolumn,spw=spw,wprojplanes=wprojplanes, verbose=True)
+
+        with open(imagename+'.return.pickle', 'wb') as handle:
+            pickle.dump(tclean_return, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
         if image_mosaic_fields_separately:
             for field_id in mosaic_field_phasecenters:

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -523,7 +523,7 @@ def get_solints_simple(vislist,scantimesdict,scanstartsdict,scanendsdict,integra
    gaincal_combine.insert(0,inf_EB_gaincal_combine)
 
    #insert solint = inf
-   if median_scans_per_obs > 1:                    # if only a single scan per target, redundant with inf_EB and do not include
+   if median_scans_per_obs > 2 or (median_scans_per_obs == 2 and max_scantime / min_scantime < 4):                    # if only a single scan per target, redundant with inf_EB and do not include
       solints_list.append('inf')
       if spwcombine:
          gaincal_combine.append('spw')

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1805,7 +1805,7 @@ def get_ALMA_bands(vislist,spwstring,spwarray):
          msmd.open(vis)
          observed_bands[vis][band]['ncorrs']=msmd.ncorrforpol(msmd.polidfordatadesc(spwarray[vis][0]))
          msmd.close()
-   get_max_uvdist(vislist,observed_bands[vislist[0]]['bands'].copy(),observed_bands)
+   get_max_uvdist(vislist,observed_bands[vislist[0]]['bands'].copy(),observed_bands,'ALMA')
    return bands,observed_bands
 
 
@@ -1881,7 +1881,7 @@ def get_VLA_bands(vislist,fields):
             bands_match=False
    if not bands_match:
      print('WARNING: INCONSISTENT BANDS IN THE MSFILES')
-   get_max_uvdist(vislist,observed_bands[vislist[0]]['bands'].copy(),observed_bands)
+   get_max_uvdist(vislist,observed_bands[vislist[0]]['bands'].copy(),observed_bands,'VLA')
    return observed_bands[vislist[0]]['bands'].copy(),observed_bands
 
 
@@ -1965,7 +1965,7 @@ def get_baseline_dist(vis):
 
 
 
-def get_max_uvdist(vislist,bands,band_properties):
+def get_max_uvdist(vislist,bands,band_properties,telescope):
    for band in bands:   
       all_baselines=np.array([])
       for vis in vislist:
@@ -1973,7 +1973,10 @@ def get_max_uvdist(vislist,bands,band_properties):
          all_baselines=np.append(all_baselines,baselines)
       max_baseline=np.max(all_baselines)
       min_baseline=np.min(all_baselines)
-      baseline_5=numpy.percentile(all_baselines,5.0)
+      if 'VLA' in telescope:
+         baseline_5=numpy.percentile(all_baselines[all_baselines > 0.05*all_baselines.max()],5.0)
+      else: # ALMA
+         baseline_5=numpy.percentile(all_baselines,5.0)
       baseline_75=numpy.percentile(all_baselines,75.0)
       baseline_median=numpy.percentile(all_baselines,50.0)
       for vis in vislist:
@@ -1984,7 +1987,7 @@ def get_max_uvdist(vislist,bands,band_properties):
          band_properties[vis][band]['minuv']=min_uv_dist
          band_properties[vis][band]['75thpct_uv']=baseline_75
          band_properties[vis][band]['median_uv']=baseline_median
-         band_properties[vis][band]['LAS']=0.6 / (1000*baseline_5) * 180./np.pi * 3600.
+         band_properties[vis][band]['LAS']=0.6 * (meanlam/baseline_5) * 180./np.pi * 3600.
 
 
 def get_uv_range(band,band_properties,vislist):

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2267,8 +2267,9 @@ def generate_weblog(sclib,solints,bands,directory='weblog'):
    htmlOut.writelines(''+bands_string+'\n')
    htmlOut.writelines('<h2>Solints to Attempt:</h2>\n')
    for band in bands:
-      solints_string=', '.join([str(elem) for elem in solints[band][target]])
-      htmlOut.writelines('<br>'+band+': '+solints_string)
+      for target in solints[band].keys():     
+         solints_string=', '.join([str(elem) for elem in solints[band][target]])
+         htmlOut.writelines('<br>'+band+': '+solints_string)
 
    for target in targets:
       htmlOut.writelines('<a name="'+target+'"></a>\n')


### PR DESCRIPTION
@jjtobin, this PR is to merge your updates for specifying a user-provided mask and or model into the refactor_code branch. Rather than merge straight into refactor_code, I thought it would make sense to put into a separate branch and open a PR to test on and discuss a few things.

A few items:

- I think I merged everything correctly, but if you are able to look it over to make sure that it seems like all is in the right place (or to test it to make sure it is doing the right thing), that would be helpful.
- I'd like to follow the principles of the refactor_code branch and store the usermodel and usermask info in the selfcal_library so that the tclean_wrapper (and usermodel_wrapper) codes can mostly handle that under-the-hood. I still need to do that.
- To that point - I see that usermodel and usermask are specified per-target but not per-band. Is there a motivation for that? I might suggest making it per-target per-band and then we can cleanly put the model into the selfcal_library and reference it from there when needed?

(Part of the reason I'm making this PR is to have some record of what I'm thinking about before the weekend. I'd say it's not ready to merge yet...)