### PR TITLE
Ensure that the fallback to pass through long baseline antennas with too much flagging works with the updates to have per-SPW caltables

### DIFF
--- a/gaincal_wrapper.py
+++ b/gaincal_wrapper.py
@@ -484,7 +484,7 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
         # reference antenna.
         if unflag_fb_to_prev_solint:
             for it, sint in enumerate(selfcal_plan['solints'][0:iteration+1]):
-                if not os.path.exists(sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][solint]['final_mode']+'.g'):
+                if not os.path.exists(sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][sint]['final_mode']+'.g') or 'combinespw' not in selfcal_library[vis][sint]['final_mode']:
                     continue
 
                 # If a previous iteration went through the unflagging routine, it is possible that some antennas fell back to
@@ -492,13 +492,13 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                 # a different time interval. So to be safe, we go back to the pre-pass solutions and then re-run the passing.
                 # We could probably check more carefully whether this is the case to avoid having to do this... but the 
                 # computing time isn't significant so it's easy just to run through again.
-                if os.path.exists(sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][solint]['final_mode']+'.pre-pass.g'):
-                    rerefant(vis, sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][solint]['final_mode']+'.pre-pass.g', \
+                if os.path.exists(sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][sint]['final_mode']+'.pre-pass.g'):
+                    rerefant(vis, sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][sint]['final_mode']+'.pre-pass.g', \
                             refant=selfcal_library[vis]["refant"], refantmode=refantmode if 'inf_EB' not in sint else 'flex')
 
-                    os.system("rm -rf "+sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][solint]['final_mode']+'.g')
-                    os.system("cp -r "+sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][solint]['final_mode']+'.pre-pass.g '+\
-                            sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][solint]['final_mode']+'.g')
+                    os.system("rm -rf "+sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][sint]['final_mode']+'.g')
+                    os.system("cp -r "+sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][sint]['final_mode']+'.pre-pass.g '+\
+                            sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][sint]['final_mode']+'.g')
 
                     if sint == "inf_EB" and len(selfcal_library[vis][sint]["spwmap"][0]) > 0:
                         unflag_spwmap = selfcal_library[vis][sint]["spwmap"][0]
@@ -506,12 +506,14 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                         unflag_spwmap = []
 
                     unflag_failed_antennas(vis, sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+\
-                            selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][solint]['final_mode']+'.g', flagged_fraction=0.25, solnorm=solnorm, \
+                            selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][sint]['final_mode']+'.g', flagged_fraction=0.25, solnorm=solnorm, \
                             only_long_baselines=selfcal_plan['solmode'][it]=="ap" if unflag_only_lbants and \
                             unflag_only_lbants_onlyap else unflag_only_lbants, calonly_max_flagged=calonly_max_flagged, \
-                            spwmap=unflag_spwmap, fb_to_prev_solint=unflag_fb_to_prev_solint, solints=selfcal_plan['solints'], iteration=it)
+                            spwmap=unflag_spwmap, fb_to_prev_solint=unflag_fb_to_prev_solint, solints=selfcal_plan['solints'], \
+                            final_modes=[selfcal_library[vis][s]['final_mode'] if s in selfcal_library[vis] else '' for s in \
+                            selfcal_plan['solints'][0:iteration]], iteration=it)
                 else:
-                    rerefant(vis, sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][solint]['final_mode']+'.g', \
+                    rerefant(vis, sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+selfcal_plan['solmode'][it]+'_'+selfcal_library[vis][sint]['final_mode']+'.g', \
                             refant=selfcal_library[vis]["refant"], refantmode=refantmode if 'inf_EB' not in sint else 'flex')
         else:
             os.system("cp -r "+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+selfcal_plan['solmode'][iteration]+'_'+selfcal_library[vis][solint]['final_mode']+'.g '+\
@@ -545,7 +547,9 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                 selfcal_plan['solmode'][iteration]+'_'+selfcal_library[vis][solint]['final_mode']+'.g', flagged_fraction=0.25, solnorm=solnorm, \
                 only_long_baselines=selfcal_plan['solmode'][iteration]=="ap" if unflag_only_lbants and unflag_only_lbants_onlyap else \
                 unflag_only_lbants, calonly_max_flagged=calonly_max_flagged, spwmap=unflag_spwmap, \
-                fb_to_prev_solint=unflag_fb_to_prev_solint, solints=selfcal_plan['solints'], iteration=iteration)
+                fb_to_prev_solint=unflag_fb_to_prev_solint, solints=selfcal_plan['solints'], \
+                final_modes=[selfcal_library[vis][s]['final_mode'] if s in selfcal_library[vis] else '' for s in \
+                selfcal_plan['solints'][0:iteration]], iteration=iteration)
 
     # Do some post-gaincal cleanup for mosaics.
     if selfcal_library['obstype'] == 'mosaic' or mode == "cocal":

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -479,6 +479,12 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                  continue
              elif delta_beamarea > delta_beam_thresh:
                  do_fallback_combinespw=False  # turn the switch off since this is another repeat
+
+                 # Remove all but combinespw modes for this iteration and subsequent ones.
+                 for vis in vislist:
+                     selfcal_plan[vis]['solint_settings'][solint]['final_mode']='combinespw' 
+                     remove_modes(selfcal_plan,vis,iteration,exclude_start=False)
+
                  print('****************Attempting applymode="calonly" fallback*************')
                  # Loop through up to two times. On the first attempt, try applymode = 'calflag' (assuming this is requested by the user). On the
                  # second attempt, use applymode = 'calonly'.

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -4091,11 +4091,11 @@ def get_min_SNR_spw(snr_per_spw):
       if snr_per_spw[spw] < minsnr: minsnr=snr_per_spw[spw]
    return minsnr
       
-def remove_modes(selfcal_plan,vis,start_index):
-    for j in range(start_index+1,len(selfcal_plan['solints'])):
+def remove_modes(selfcal_plan,vis,start_index,exclude_start=True):
+    preferred_mode=selfcal_plan[vis]['solint_settings'][selfcal_plan['solints'][start_index]]['final_mode']
+    for j in range(start_index+int(exclude_start),len(selfcal_plan['solints'])):
        if 'ap' in selfcal_plan['solints'][j] and 'ap' not in selfcal_plan['solints'][start_index]: # exempt over ap solints since they go back to a longer solint
           continue
-       preferred_mode=selfcal_plan[vis]['solint_settings'][selfcal_plan['solints'][j]]['final_mode']
        if preferred_mode == 'per_bb' or preferred_mode == 'combinespw':
           if 'per_spw' in selfcal_plan[vis]['solint_settings'][selfcal_plan['solints'][j]]['modes_to_attempt']:
              selfcal_plan[vis]['solint_settings'][selfcal_plan['solints'][j]]['modes_to_attempt'].remove('per_spw')

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -3492,7 +3492,7 @@ def get_gaintable_flagging_stats(gc_dict_list,spwlist):
 
 
 def unflag_failed_antennas(vis, caltable, flagged_fraction=0.25, only_long_baselines=False, solnorm=True, calonly_max_flagged=0., spwmap=[], 
-        fb_to_prev_solint=False, solints=[], iteration=0, plot=False, plot_directory="./"):
+        fb_to_prev_solint=False, solints=[], final_modes=[], iteration=0, plot=False, plot_directory="./"):
     tb.open(caltable, nomodify=plot) # Because we only modify if we aren't plotting, i.e. in the selfcal loop itself plot=False
     antennas = tb.getcol("ANTENNA1")
     flags = tb.getcol("FLAG")
@@ -3710,13 +3710,14 @@ def unflag_failed_antennas(vis, caltable, flagged_fraction=0.25, only_long_basel
     # Check whether earlier solints have acceptable solutions, and if so use, those instead.
 
     if fb_to_prev_solint:
-        if "ap" in solints[iteration]:
-            for i in range(len(solints)):
-                if "ap" in solints[i]:
+        min_iter = iteration
+        for i in range(1,iteration)[::-1]:
+            if "combinespw" in final_modes[i]:
+                if "ap" in solints[iteration]:
+                    if "ap" in solints[i]:
+                        min_iter = i
+                else:
                     min_iter = i
-                    break
-        else:
-            min_iter = 1
 
         for i, solint in enumerate(solints[min_iter:iteration][::-1]):
             print("Testing solint ", solint)


### PR DESCRIPTION
I believe, though it has now been some time so my memory is a little fuzzy, that this initially came about because once the per-SPW/BB caltables were added, there was a case where the initial attempt at calibration picked either per-SPW or per-BB as the preferred mode. That solution failed, so it did the combinespw fallback and still failed because of a beam-size change. It thus did the "calonly" fallback, but because the combinespw fallback had failed, per-SPW and per-BB were still options. I don't recall which mode it ultimately picked, but regardless, my recollection is that the selfcal actually continued successfully, and it didn't break until the weblog. At that point, because unflagging had been done, when the weblog looped over all modes for that solint, it was looking for the "*.pre-pass" version of the gaintable, but could only find it for the preferred mode and therefore crashed.

After some thought, I decided that the simplest solution would be that in the event that we reached the "calonly" fallback, that only the combinespw option should be considered, and all other modes should be removed for future solints (resetting for ap solints).

It also, as I was working on this, occurred to me that the option for antennas to fall back to previous successful solint solutions rather than being "passed through" should only consider previous combinespw solints, as others all get applied. It would also make for very confusing code/gaintables to be mixing per-spw and not...

This PR fixes both of those issues.